### PR TITLE
fix: 强化本地上传端点安全策略

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -86,16 +86,16 @@ func GetDefaults() *Config {
 		FeatureGate: FeatureGateConfig{
 			LicenseKey: "demo-license-xyz",
 		},
-                Storage: StorageConfig{
-                        DefaultDriver: "local",
-                        TTLSeconds:    43200,
-                        Local: LocalStorageConfig{
-                                BasePath:             "./storage/media",
-                                PublicBaseURL:        "http://localhost:8077/media",
-                                EnableUploadEndpoint: true,
-                                UploadTokenSecret:    "",
-                                MaxUploadSizeBytes:   100 << 20, // 100MB
-                        },
+		Storage: StorageConfig{
+			DefaultDriver: "local",
+			TTLSeconds:    43200,
+			Local: LocalStorageConfig{
+				BasePath:             "./storage/media",
+				PublicBaseURL:        "http://localhost:8077/media",
+				EnableUploadEndpoint: false,
+				UploadTokenSecret:    "",
+				MaxUploadSizeBytes:   100 << 20, // 100MB
+			},
 			S3: S3StorageConfig{
 				Endpoint:       "http://127.0.0.1:9000",
 				Region:         "us-east-1",

--- a/config/validator.go
+++ b/config/validator.go
@@ -97,6 +97,11 @@ func (c *Config) Validate() error {
 			errors = append(errors, "storage.local.base_path 不能为空")
 		}
 	}
+	if c.Storage.Local.EnableUploadEndpoint {
+		if strings.TrimSpace(c.Storage.Local.UploadTokenSecret) == "" {
+			errors = append(errors, "storage.local.upload_token_secret 不能为空（启用 enable_upload_endpoint 时）")
+		}
+	}
 	if strings.EqualFold(c.Storage.DefaultDriver, "s3") {
 		if strings.TrimSpace(c.Storage.S3.Endpoint) == "" {
 			errors = append(errors, "storage.s3.endpoint 不能为空")

--- a/etc/config_example.yaml
+++ b/etc/config_example.yaml
@@ -250,8 +250,8 @@ storage:
   local:
     base_path: ./storage/media
     public_base_url: http://localhost:8077/media
-    enable_upload_endpoint: true
-    upload_token_secret: ""
+    enable_upload_endpoint: false
+    upload_token_secret: ""  # 启用上传端点时必须显式配置强随机密钥
     max_upload_size_bytes: 104857600
   s3:
     endpoint: http://127.0.0.1:9000

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -76,8 +76,8 @@ func BootstrapApp(ctx context.Context, cfg *config.Config) (*shared.Deps, error)
 	accessTTL, _ := time.ParseDuration(cfg.Auth.AccessTTLStr)
 	refreshTTL, _ := time.ParseDuration(cfg.Auth.RefreshTTLStr)
 	localTokenSecret := strings.TrimSpace(cfg.Storage.Local.UploadTokenSecret)
-	if localTokenSecret == "" {
-		localTokenSecret = strings.TrimSpace(cfg.Server.SecretKey)
+	if cfg.Storage.Local.EnableUploadEndpoint && localTokenSecret == "" {
+		logger.WarnF(ctx, "storage.local.enable_upload_endpoint 已启用，但未配置 upload_token_secret，上传端点将在路由层被禁用")
 	}
 	maxUploadSize := cfg.Storage.Local.MaxUploadSizeBytes
 	if maxUploadSize < 0 {

--- a/internal/http/middleware/local_upload.go
+++ b/internal/http/middleware/local_upload.go
@@ -44,7 +44,8 @@ func RegisterLocalUploadEndpoint(r *gin.Engine, cfg *config.Config) {
 	}
 	secret := strings.TrimSpace(localOpts.UploadTokenSecret)
 	if secret == "" {
-		secret = strings.TrimSpace(cfg.Server.SecretKey)
+		pxlog.Warn(nil, "未注册本地上传端点：启用 enable_upload_endpoint 时必须配置 upload_token_secret")
+		return
 	}
 	maxSize := localOpts.MaxUploadSizeBytes
 	if maxSize < 0 {


### PR DESCRIPTION
## Summary
- 禁用默认配置中的本地存储上传端点，要求显式配置 upload_token_secret 才能开放
- 在配置校验与应用引导流程中提示缺失密钥的风险，防止无密钥时仍注册上传路由
- 更新示例配置与路由注册日志文案，明确启用上传功能时的安全要求

## Testing
- go test ./... *(fails: workspace 缺失大量 go.sum 依赖)*

------
https://chatgpt.com/codex/tasks/task_e_68ea6fbb95608325b37df652923dd600