### PR TITLE
 - LLM 驱动里重写了百度千帆支持：默认按 v2(OpenAI 兼容) 方式调用 https://qianfan.baidubce.c…

### DIFF
--- a/backend/config/agents/providers.d/baidu_wenxin.yaml
+++ b/backend/config/agents/providers.d/baidu_wenxin.yaml
@@ -37,6 +37,40 @@ modalities:
         label: "ERNIE Bot (base)"
         tags: ["general"]
         defaults: { temperature: 0.7, max_tokens: 1024 }
+      - id: ERNIE-Lite-8K
+        label: "ERNIE Lite 8K (Free)"
+        tags: ["lite","free","cost-optimized"]
+        defaults: { temperature: 0.7, max_tokens: 1024 }
+        limits: { context_window: 8192 }
+      - id: ERNIE-Tiny-8K
+        label: "ERNIE Tiny 8K"
+        tags: ["lite","cheap","latency"]
+        defaults: { temperature: 0.7, max_tokens: 1024 }
+        limits: { context_window: 8192 }
+      - id: ernie-4.0-8k
+        label: "ERNIE 4.0 8K"
+        tags: ["flagship","multimodal","v2"]
+        defaults: { temperature: 0.7, max_tokens: 1024 }
+      - id: ernie-4.0-128k
+        label: "ERNIE 4.0 128K"
+        tags: ["flagship","long-context","v2"]
+        defaults: { temperature: 0.7, max_tokens: 1024 }
+      - id: ernie-3.5-8k
+        label: "ERNIE 3.5 8K"
+        tags: ["general","balanced","v2"]
+        defaults: { temperature: 0.7, max_tokens: 1024 }
+      - id: ernie-speed-8k
+        label: "ERNIE Speed 8K (v2)"
+        tags: ["fast","cheap","v2"]
+        defaults: { temperature: 0.7, max_tokens: 1024 }
+      - id: ernie-speed-128k
+        label: "ERNIE Speed 128K (v2)"
+        tags: ["fast","long-context","v2"]
+        defaults: { temperature: 0.7, max_tokens: 1024 }
+      - id: ernie-lite-8k
+        label: "ERNIE Lite 8K (v2)"
+        tags: ["free","lite","v2"]
+        defaults: { temperature: 0.7, max_tokens: 1024 }
   embedding:
     models:
       - id: embedding-v1

--- a/backend/config/agents/providers.d/openai.yaml
+++ b/backend/config/agents/providers.d/openai.yaml
@@ -22,31 +22,52 @@ modalities:
       - id: gpt-4o
         label: "GPT-4o"
         tags: ["omni","multimodal","flagship"]
-        defaults: { temperature: 0.7, max_tokens: 1024 }
+        defaults:
+          temperature: 0.7
+          max_tokens: 1024
+          api_path: "/v1/chat/completions"
       - id: gpt-4o-mini
         label: "GPT-4o mini"
         tags: ["fast","cheap"]
-        defaults: { temperature: 0.7, max_tokens: 1024 }
+        defaults:
+          temperature: 0.7
+          max_tokens: 1024
+          api_path: "/v1/chat/completions"
       - id: gpt-4.1-mini
         label: "GPT-4.1 mini"
         tags: ["json"]
-        defaults: { temperature: 0.3, max_tokens: 1024 }
+        defaults:
+          temperature: 0.3
+          max_tokens: 1024
+          api_path: "/v1/chat/completions"
       - id: o3
         label: "OpenAI o3"
         tags: ["reasoning","deep"]
-        defaults: { temperature: 0.2, max_tokens: 1024 }
+        defaults:
+          temperature: 0.2
+          max_tokens: 1024
+          api_path: "/v1/chat/completions"
       - id: o4-mini
         label: "OpenAI o4-mini"
         tags: ["reasoning","cost-effective"]
-        defaults: { temperature: 0.3, max_tokens: 1024 }
+        defaults:
+          temperature: 0.3
+          max_tokens: 1024
+          api_path: "/v1/chat/completions"
       - id: o4-mini-high
         label: "OpenAI o4-mini-high"
         tags: ["reasoning","high-effort","accuracy"]
-        defaults: { temperature: 0.2, max_tokens: 1024 }
+        defaults:
+          temperature: 0.2
+          max_tokens: 1024
+          api_path: "/v1/chat/completions"
       - id: gpt-3.5-turbo
         label: "GPT-3.5 Turbo"
         tags: ["fast","cheap"]
-        defaults: { temperature: 0.7, max_tokens: 1024 }
+        defaults:
+          temperature: 0.7
+          max_tokens: 1024
+          api_path: "/v1/chat/completions"
 
   embedding:
     models:

--- a/backend/etc/config_example.yaml
+++ b/backend/etc/config_example.yaml
@@ -205,7 +205,8 @@ low_code:
 
 ai:
   catalog:
-    dirs: []
+    dirs:
+      - "./config/agents/providers.d"
     include_embedded: true
     fail_if_empty: false
     hot_reload: false

--- a/backend/internal/server/agent/catalog/registry.go
+++ b/backend/internal/server/agent/catalog/registry.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -148,6 +149,7 @@ func (r *Registry) LoadByConfig(cfg CatalogConfig, embedded fs.FS) error {
 		wd, _ := os.Getwd()
 		return fmt.Errorf("no provider manifests loaded from dirs=%v (wd=%s)", absDirs, wd)
 	}
+	log.Printf("[ai.catalog] loaded %d provider manifests from dirs=%v", total, absDirs)
 	return nil
 }
 
@@ -259,9 +261,17 @@ func GetGlobalAIRegister() *Registry {
 
 // InitFromAppConfig：由你的主配置调用
 func InitFromAppConfig(cfg CatalogConfig, embedded fs.FS) error {
+	if len(cfg.Dirs) == 0 {
+		cfg.Dirs = []string{"./config/agents/providers.d"}
+	}
+	log.Printf("[ai.catalog] initializing registry, dirs=%v include_embedded=%v", cfg.Dirs, cfg.IncludeEmbedded)
 	reg := NewRegistry()
 	if err := reg.LoadByConfig(cfg, embedded); err != nil {
 		return err
+	}
+	if len(reg.providers) == 0 {
+		wd, _ := os.Getwd()
+		log.Printf("[ai.catalog] warning: registry empty after load (wd=%s)", wd)
 	}
 	GlobalAIRegister = reg
 

--- a/backend/internal/server/agent/config/ai.go
+++ b/backend/internal/server/agent/config/ai.go
@@ -84,8 +84,9 @@ type AIRouting struct {
 
 func (c *AIConfig) SetDefaults() {
 	// Catalog
-	if c.Catalog.FailIfEmpty == false && len(c.Catalog.Dirs) == 0 {
-		// 不强行设默认目录；由你的主配置完全控制
+	if len(c.Catalog.Dirs) == 0 {
+		// 默认使用仓库内置的 provider 目录，避免忘记配置时 registry 为空
+		c.Catalog.Dirs = []string{"./config/agents/providers.d"}
 	}
 	// Defaults.LLM
 	if c.Defaults.LLM.Temperature == 0 {

--- a/backend/internal/server/agent/drivers/eino/llm/baidu.go
+++ b/backend/internal/server/agent/drivers/eino/llm/baidu.go
@@ -25,13 +25,63 @@ type baiduClient struct{}
 
 func NewBaiduClient() LLMClient { return &baiduClient{} }
 
-func (c *baiduClient) endpoint(mc *config.ModelConfig) string {
-	base := strings.TrimRight(mc.Endpoint, "/")
-	if base == "" {
-		base = "https://aip.baidubce.com"
+const (
+	defaultQianfanV2Base = "https://qianfan.baidubce.com/v2"
+	defaultLegacyBase    = "https://aip.baidubce.com"
+	legacyPath           = "/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/completions"
+	v2Path               = "/chat/completions"
+)
+
+type qianfanMode int
+
+const (
+	modeV2 qianfanMode = iota
+	modeLegacy
+)
+
+func (c *baiduClient) resolveMode(mc *config.ModelConfig) qianfanMode {
+	if t := strings.ToLower(strings.TrimSpace(mc.APIType)); t != "" {
+		if t == "legacy" || t == "rpc" {
+			return modeLegacy
+		}
+		if t == "v2" || t == "openai" {
+			return modeV2
+		}
 	}
-	// 你也可以根据 mc.Model 衍生具体子路径，这里统一用 chat/completions
-	return base + "/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/completions"
+	base := strings.ToLower(strings.TrimSpace(mc.Endpoint))
+	switch {
+	case strings.Contains(base, "aip.baidubce.com") || strings.Contains(base, "/rpc/2.0/"):
+		return modeLegacy
+	case base == "":
+		return modeV2
+	default:
+		if strings.Contains(base, "qianfan") || strings.Contains(base, "/v2") {
+			return modeV2
+		}
+	}
+	// 默认走新版
+	return modeV2
+}
+
+func (c *baiduClient) endpoint(mc *config.ModelConfig, mode qianfanMode) string {
+	base := strings.TrimRight(strings.TrimSpace(mc.Endpoint), "/")
+	if mode == modeV2 {
+		if base == "" {
+			base = defaultQianfanV2Base
+		} else if strings.HasSuffix(base, "/v1") {
+			base = strings.TrimSuffix(base, "/v1") + "/v2"
+		} else if !strings.HasSuffix(base, "/v2") && !strings.Contains(base, "/v2/") {
+			// 如果包含 qianfan 但没写版本，默认补上 /v2
+			if strings.Contains(strings.ToLower(base), "qianfan") {
+				base += "/v2"
+			}
+		}
+		return strings.TrimRight(base, "/") + v2Path
+	}
+	if base == "" || strings.Contains(strings.ToLower(base), "qianfan") {
+		base = defaultLegacyBase
+	}
+	return base + legacyPath
 }
 
 func (c *baiduClient) httpClient(mc *config.ModelConfig) *http.Client {
@@ -42,7 +92,7 @@ func (c *baiduClient) httpClient(mc *config.ModelConfig) *http.Client {
 	return &http.Client{Timeout: to}
 }
 
-func (c *baiduClient) makeBody(mc *config.ModelConfig, userMessage string, streaming bool) ([]byte, error) {
+func (c *baiduClient) makeBody(mc *config.ModelConfig, userMessage string, streaming bool, includeModel bool) ([]byte, error) {
 	sys := strings.TrimSpace(mc.SystemPrompt)
 	msgs := []map[string]string{
 		{"role": "system", "content": sys},
@@ -51,6 +101,11 @@ func (c *baiduClient) makeBody(mc *config.ModelConfig, userMessage string, strea
 	req := map[string]any{
 		"messages": msgs,
 		"stream":   streaming,
+	}
+	if includeModel {
+		if m := strings.TrimSpace(resolveQianfanModel(mc.Model)); m != "" {
+			req["model"] = m
+		}
 	}
 	if mc.Temperature > 0 {
 		req["temperature"] = mc.Temperature
@@ -61,7 +116,7 @@ func (c *baiduClient) makeBody(mc *config.ModelConfig, userMessage string, strea
 	}
 	// 透传扩展
 	for k, v := range mc.Extra {
-		if k == "temperature" || k == "max_output_tokens" || k == "stream" || k == "messages" {
+		if k == "temperature" || k == "max_output_tokens" || k == "stream" || k == "messages" || k == "model" {
 			continue
 		}
 		req[k] = v
@@ -69,33 +124,39 @@ func (c *baiduClient) makeBody(mc *config.ModelConfig, userMessage string, strea
 	return json.Marshal(req)
 }
 
-func (c *baiduClient) authToken(mc *config.ModelConfig) (string, error) {
-	// 优先 AccessToken；回退 APIKey
-	token := strings.TrimSpace(mc.AccessToken)
-	if token == "" {
-		token = strings.TrimSpace(mc.APIKey)
+func resolveQianfanModel(model string) string {
+	m := strings.TrimSpace(model)
+	if m == "" {
+		return ""
 	}
-	if token == "" {
-		return "", errors.New("baidu: missing access_token or api_key")
+	normalized := strings.ToLower(strings.ReplaceAll(m, "_", "-"))
+	aliases := map[string]string{
+		"ernie-bot-4":      "ernie-4.0-8k",
+		"ernie-bot":        "ernie-3.5-8k",
+		"ernie-speed-8k":   "ernie-speed-8k",
+		"ernie-speed-128k": "ernie-speed-128k",
+		"ernie-lite-8k":    "ernie-lite-8k",
+		"ernie-tiny-8k":    "ernie-tiny-8k",
 	}
-	return token, nil
+	if mapped, ok := aliases[normalized]; ok {
+		return mapped
+	}
+	return m
 }
 
 /* ------------------- Invoke（非流式） ------------------- */
 
 func (c *baiduClient) Invoke(ctx context.Context, mc *config.ModelConfig, userMessage string) (string, error) {
-	token, err := c.authToken(mc)
-	if err != nil {
-		return "", err
-	}
-	body, err := c.makeBody(mc, userMessage, false)
+	mode := c.resolveMode(mc)
+	body, err := c.makeBody(mc, userMessage, false, mode == modeV2)
 	if err != nil {
 		return "", err
 	}
 
-	url := c.endpoint(mc) + "?access_token=" + token
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
+	req, err := c.buildRequest(ctx, mc, body, mode)
+	if err != nil {
+		return "", err
+	}
 
 	resp, err := c.httpClient(mc).Do(req)
 	if err != nil {
@@ -113,11 +174,7 @@ func (c *baiduClient) Invoke(ctx context.Context, mc *config.ModelConfig, userMe
 		return "", err
 	}
 
-	// 常见：直接 result
-	if s, ok := jr["result"].(string); ok && s != "" {
-		return s, nil
-	}
-	// 兼容：choices[0].message.content
+	// V2：OpenAI 兼容响应
 	if ch, ok := jr["choices"].([]any); ok && len(ch) > 0 {
 		if first, ok := ch[0].(map[string]any); ok {
 			if msg, ok := first["message"].(map[string]any); ok {
@@ -125,10 +182,37 @@ func (c *baiduClient) Invoke(ctx context.Context, mc *config.ModelConfig, userMe
 					return s, nil
 				}
 			}
+			if delta, ok := first["delta"].(map[string]any); ok {
+				if s, ok := delta["content"].(string); ok && s != "" {
+					return s, nil
+				}
+			}
 		}
 	}
-	// 错误字段（不同版本可能是 error_code / error_msg）
+	// 旧版：result 字段
+	if s, ok := jr["result"].(string); ok && s != "" {
+		return s, nil
+	}
+	// 错误字段
+	if errMap, ok := jr["error"].(map[string]any); ok {
+		msg := ""
+		if m, ok := errMap["message"].(string); ok {
+			msg = m
+		}
+		if code, ok := errMap["code"].(string); ok {
+			if msg != "" {
+				return "", fmt.Errorf("baidu: %s (%s)", msg, code)
+			}
+			msg = code
+		}
+		if msg != "" {
+			return "", errors.New("baidu: " + msg)
+		}
+	}
 	if em, ok := jr["error_msg"].(string); ok && em != "" {
+		return "", errors.New("baidu: " + em)
+	}
+	if em, ok := jr["msg"].(string); ok && em != "" {
 		return "", errors.New("baidu: " + em)
 	}
 	return "", errors.New("baidu: unexpected response")
@@ -137,18 +221,16 @@ func (c *baiduClient) Invoke(ctx context.Context, mc *config.ModelConfig, userMe
 /* ------------------- Stream（增量） ------------------- */
 
 func (c *baiduClient) Stream(ctx context.Context, mc *config.ModelConfig, prompt string, onDelta func(string)) (string, error) {
-	token, err := c.authToken(mc)
-	if err != nil {
-		return "", err
-	}
-	body, err := c.makeBody(mc, prompt, true)
+	mode := c.resolveMode(mc)
+	body, err := c.makeBody(mc, prompt, true, mode == modeV2)
 	if err != nil {
 		return "", err
 	}
 
-	url := c.endpoint(mc) + "?access_token=" + token
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
+	req, err := c.buildRequest(ctx, mc, body, mode)
+	if err != nil {
+		return "", err
+	}
 
 	resp, err := c.httpClient(mc).Do(req)
 	if err != nil {
@@ -191,27 +273,82 @@ func (c *baiduClient) Stream(ctx context.Context, mc *config.ModelConfig, prompt
 			// 无法解析本行，略过
 			continue
 		}
-		// 错误字段
-		if em, ok := chunk["error_msg"].(string); ok && em != "" {
-			return final.String(), errors.New("baidu: " + em)
+		if err := c.handleStreamChunk(chunk, mode, onDelta, &final); err != nil {
+			return final.String(), err
 		}
-		// 增量内容字段（常见：result）
-		if s, ok := chunk["result"].(string); ok && s != "" {
-			if onDelta != nil {
-				onDelta(s)
-			}
-			final.WriteString(s)
-		}
-		// 结束字段（is_end / done）
-		if done, ok := chunk["is_end"].(bool); ok && done {
-			break
-		}
-		if done, ok := chunk["done"].(bool); ok && done {
-			break
-		}
-	}
-	if err := sc.Err(); err != nil && !errors.Is(err, io.EOF) {
-		return final.String(), err
 	}
 	return final.String(), nil
+}
+
+func (c *baiduClient) handleStreamChunk(chunk map[string]any, mode qianfanMode, onDelta func(string), final *strings.Builder) error {
+	if mode == modeV2 {
+		if errObj, ok := chunk["error"].(map[string]any); ok {
+			msg := ""
+			if m, ok := errObj["message"].(string); ok {
+				msg = m
+			}
+			if msg == "" {
+				msg = "baidu stream error"
+			}
+			return errors.New(msg)
+		}
+		if choices, ok := chunk["choices"].([]any); ok && len(choices) > 0 {
+			if choice, ok := choices[0].(map[string]any); ok {
+				if delta, ok := choice["delta"].(map[string]any); ok {
+					if content, ok := delta["content"].(string); ok && content != "" {
+						if onDelta != nil {
+							onDelta(content)
+						}
+						final.WriteString(content)
+					}
+				}
+				if reason, ok := choice["finish_reason"].(string); ok && reason != "" && strings.EqualFold(reason, "stop") {
+					return nil
+				}
+			}
+		}
+		return nil
+	}
+	// legacy
+	if em, ok := chunk["error_msg"].(string); ok && em != "" {
+		return errors.New("baidu: " + em)
+	}
+	if s, ok := chunk["result"].(string); ok && s != "" {
+		if onDelta != nil {
+			onDelta(s)
+		}
+		final.WriteString(s)
+	}
+	return nil
+}
+
+func (c *baiduClient) buildRequest(ctx context.Context, mc *config.ModelConfig, body []byte, mode qianfanMode) (*http.Request, error) {
+	url := c.endpoint(mc, mode)
+	reqURL := url
+	if mode == modeLegacy {
+		token := strings.TrimSpace(mc.AccessToken)
+		if token == "" {
+			token = strings.TrimSpace(mc.APIKey)
+		}
+		if token == "" {
+			return nil, errors.New("baidu: missing access_token or api_key")
+		}
+		reqURL = url + "?access_token=" + token
+	}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if mode == modeV2 {
+		token := strings.TrimSpace(mc.APIKey)
+		if token == "" {
+			token = strings.TrimSpace(mc.AccessToken)
+		}
+		if token == "" {
+			return nil, errors.New("baidu: missing api_key")
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		if appID := strings.TrimSpace(mc.Organization); appID != "" {
+			req.Header.Set("appid", appID)
+		}
+	}
+	return req, nil
 }

--- a/backend/internal/server/agent/drivers/eino/llm/openai.go
+++ b/backend/internal/server/agent/drivers/eino/llm/openai.go
@@ -19,6 +19,8 @@ type openaiClient struct{ NoopStream }
 
 func NewOpenAIClient() LLMClient { return &openaiClient{} }
 
+const defaultOpenAIPath = "/v1/chat/completions"
+
 /* ------------ 公共结构 ------------ */
 
 type openAIChatReq struct {
@@ -86,7 +88,8 @@ func (c *openaiClient) buildEndpointAndHeaders(mc *config.ModelConfig, streaming
 	}
 	h.Set("Authorization", "Bearer "+mc.APIKey)
 	h.Set("Content-Type", "application/json")
-	url := base + "/v1/chat/completions"
+	path := resolveAPIPath(mc)
+	url := joinEndpoint(base, path)
 	return url, h, nil
 }
 
@@ -248,4 +251,29 @@ func (c *openaiClient) Stream(ctx context.Context, mc *config.ModelConfig, promp
 		}
 	}
 	return final.String(), nil
+}
+
+func resolveAPIPath(mc *config.ModelConfig) string {
+	if mc != nil && mc.Extra != nil {
+		if raw, ok := mc.Extra["api_path"]; ok {
+			if s, ok2 := raw.(string); ok2 {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					if !strings.HasPrefix(s, "/") {
+						s = "/" + s
+					}
+					return s
+				}
+			}
+		}
+	}
+	return defaultOpenAIPath
+}
+
+func joinEndpoint(base, path string) string {
+	trimmed := strings.TrimRight(base, "/")
+	if trimmed == "" {
+		trimmed = base
+	}
+	return trimmed + path
 }

--- a/backend/internal/service/agent/agent_setting_service.go
+++ b/backend/internal/service/agent/agent_setting_service.go
@@ -330,6 +330,7 @@ func (s *AgentSettingService) PingLLM(ctx context.Context, env string, tenantUUI
 		Temperature:  0.0,
 		MaxTokens:    8,
 		AccessToken:  apiKey,
+		Extra:        s.buildModelExtras(contract.ModLLM, provider, model),
 	}
 	cli, err := agentllm.NewClient(provider)
 	if err != nil {
@@ -383,6 +384,7 @@ func (s *AgentSettingService) QuickCallLLM(
 		Temperature:  temperature,
 		MaxTokens:    utils.MaxInt(maxTokens, 64),
 		AccessToken:  apiKey,
+		Extra:        s.buildModelExtras(contract.ModLLM, provider, model),
 	}
 	cli, err := agentllm.NewClient(provider)
 	if err != nil {
@@ -463,6 +465,19 @@ func ensureModelExists(modality, provider, model string) error {
 	}
 	if manifest := findModelManifest(modality, provider, model); manifest == nil {
 		return fmt.Errorf("provider %s 不包含模型 %s (%s)", provider, model, modality)
+	}
+	return nil
+}
+
+func (s *AgentSettingService) buildModelExtras(modality contract.Modality, provider, model string) map[string]any {
+	manifest := findModelManifest(string(modality), provider, model)
+	if manifest == nil || manifest.Defaults == nil {
+		return nil
+	}
+	if raw, ok := manifest.Defaults["api_path"]; ok {
+		if path, ok2 := raw.(string); ok2 && strings.TrimSpace(path) != "" {
+			return map[string]any{"api_path": path}
+		}
 	}
 	return nil
 }

--- a/backend/internal/transport/http/admin/agent/setting_handler.go
+++ b/backend/internal/transport/http/admin/agent/setting_handler.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	dtoRequest "github.com/ArtisanCloud/PowerX/pkg/dto"
 	"github.com/gin-gonic/gin"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 // 依赖注入
@@ -778,14 +780,25 @@ func (h *AgentSettingHandler) getActiveProfile(c *gin.Context) {
 	}
 	tenantRef := tenantCtx.UUIDPtr()
 	prof, err := h.svc.GetActiveProfile(c.Request.Context(), env, tenantRef, mod)
-	if err != nil || prof == nil {
-		dtoRequest.ResponseError(c, http.StatusBadRequest, "未找到激活画像", err)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		dtoRequest.ResponseError(c, http.StatusInternalServerError, "查询激活配置失败", err)
+		return
+	}
+	if prof == nil {
+		dtoRequest.ResponseSuccess(c, gin.H{
+			"env":        env,
+			"modality":   mod,
+			"profile":    nil,
+			"configured": false,
+			"message":    "当前模态尚未配置模型，请先在 AI 设置中保存。",
+		})
 		return
 	}
 	dtoRequest.ResponseSuccess(c, gin.H{
-		"env":      env,
-		"modality": mod,
-		"profile":  prof, // ✅ 只有一条
+		"env":        env,
+		"modality":   mod,
+		"profile":    prof, // ✅ 只有一条
+		"configured": true,
 	})
 }
 

--- a/docs/guides/agent/ai_setting.md
+++ b/docs/guides/agent/ai_setting.md
@@ -1,0 +1,45 @@
+# AI 设置与主模型生效流程
+
+PowerX 的「AI 设置」页面提供了统一的 Provider/模型管理；理解其落库与生效顺序，能帮你快速定位“为什么切换 provider 没有真正生效”的问题。
+
+## 默认配置
+
+1. **后端默认值**：若从未在后台保存任何配置，Agent 将使用 `backend/etc/config_example.yaml` 中 `ai.defaults` 段配置的 provider / model / endpoint。这是编译期的静态兜底，适合本地开发。
+2. **环境隔离**：页面左侧的环境切换（默认 `default`）会把不同环境的数据保存在各自的 scope 下，后端通过 `env + tenant` 二元索引区分，同一个 provider 可以在不同环境配置不同的 key。
+
+## 保存一次 = 落两个实体
+
+点击页面的「保存」会触发 `AgentSettingService.SaveCredentialAndProfile`，落库逻辑如下：
+
+| 实体 | 说明 |
+| --- | --- |
+| `ai_provider_credentials` | 记录 provider 的 `base_url`、`api_key` 等敏感字段。重复保存会自动加密并“保留旧的 __sealed”。 |
+| `ai_model_profiles` | 记录当前模态的 provider/model 组合以及默认参数（温度、max_tokens 等）。 |
+
+换句话说，你可以先把不同 provider 的凭据都保存好，作为候选。此时数据库里会有多条 profile/credential，但 Agent 仍然会沿用「当前激活配置」。
+
+## 选择谁当主模型？
+
+真正决定“系统主智能体”使用哪个 provider/model 的，是 `ai_route_policies` 中的默认路由（`SetActiveProfile` 会写入 Name=`__default` 的记录）：
+
+1. 在页面切换到目标 provider/model。
+2. （可选）点击「测试连接」保证连通性通过。
+3. 点击「保存」。这一步不仅更新 profile/credential，还会把该 provider/model 写入默认路由，后端随即改用新的组合。
+
+> ⚠️ **仅切换下拉框不生效**：如果你仅切换 provider 但没有点击「保存」，前端状态会改变，但数据库里的默认路由不会更新，Agent 仍然调用旧模型。
+
+## 多 provider 场景
+
+- 你可以为多个 provider 各自保存凭据、参数，但同一模态下始终只有一个“激活”组合。需要切换时，选中后再次点击「保存」，系统会覆盖默认路由。
+- 若想恢复默认（或某个候选）配置，只需切到对应 provider，检查参数无误后点击「保存」即可。
+- 删除/禁用某 provider 之前，建议先把默认路由切到其他 provider，避免出现“找不到激活 profile”。
+
+## 常见问题排查
+
+| 现象 | 可能原因 | 处理方式 |
+| --- | --- | --- |
+| 后端日志仍显示旧 provider | 切换后未点击「保存」；或保存失败 | 查看页面提示/浏览器 Network，确认 `…/settings/save` 返回成功 |
+| Base URL 不随 provider 清空 | 老版前端会缓存，记得刷新页面或在「保存」前手动覆盖 | 当前版本已在 provider 切换时同步；若仍遇到，重载页面确认 |
+| 环境切换后配置不对 | 环境 store 未刷新 | 先切换环境，下方状态加载完成后再进行操作 |
+
+掌握上述流程后，可以放心地把多个 provider 的信息一次性录入，只需记得“切换谁 → 就立即保存”来更新默认主模型。 ***

--- a/web-admin/app/pages/settings/ai/index.vue
+++ b/web-admin/app/pages/settings/ai/index.vue
@@ -510,6 +510,7 @@ async function onProviderChanged(nextProvider?: string) {
 
   // 关键：参数不全就短路，但不清空 models
   if (!rawProvider || !currentModality) {
+    syncCredentialFieldsForProvider(rawProvider);
     return;
   }
 
@@ -523,6 +524,55 @@ async function onProviderChanged(nextProvider?: string) {
   } catch (error) {
     console.error("获取模型列表失败:", error);
     // 这里不清空，保持上一次成功值
+  }
+
+  syncCredentialFieldsForProvider(rawProvider);
+}
+
+function syncCredentialFieldsForProvider(provider?: string | null) {
+  const targetProvider = (provider ?? "").trim();
+  const state = currentState.value as BaseConn & Record<string, any>;
+  const getter =
+    typeof aiSettingsStore.getCredentialByProvider === "function"
+      ? aiSettingsStore.getCredentialByProvider
+      : null;
+  const data = (getter ? getter(targetProvider)?.data ?? {} : {}) as Record<
+    string,
+    any
+  >;
+  const assign = (field: string, value: string) => {
+    state[field] = value;
+  };
+
+  const clearConnectionFields = () => {
+    assign("baseURL", "");
+    assign("organization", "");
+    assign("region", "");
+    if ("azureDeployment" in state) {
+      assign("azureDeployment", "");
+    }
+  };
+
+  if (!targetProvider) {
+    clearConnectionFields();
+    return;
+  }
+
+  const getString = (key: string) => {
+    const val = data[key];
+    return typeof val === "string" ? val : "";
+  };
+
+  const baseURL = getString("base_url");
+  const organization = getString("organization");
+  const region = getString("region");
+  const azureDeployment = getString("azure_deployment");
+
+  assign("baseURL", baseURL);
+  assign("organization", organization);
+  assign("region", region);
+  if ("azureDeployment" in state) {
+    assign("azureDeployment", azureDeployment);
   }
 }
 

--- a/web-admin/app/plugins/ai-settings.client.ts
+++ b/web-admin/app/plugins/ai-settings.client.ts
@@ -14,6 +14,10 @@ export default defineNuxtPlugin((nuxtApp) => {
     if (!token || route.meta.auth === false) return; // 登录就绪 + 受保护页才初始化
 
     try {
+      const userStore = useUserStore();
+      if (!userStore.context) {
+        await userStore.fetchUserContext();
+      }
       const store = useAISettingsStore();
       await store.initialize();
       initialized.value = true;

--- a/web-admin/i18n/locales/zh.json
+++ b/web-admin/i18n/locales/zh.json
@@ -35,6 +35,20 @@
       "untitled": "未命名分类"
     }
   },
+  "auth": {
+    "backToHome": "返回首页",
+    "welcomeBack": "欢迎回来",
+    "loginSubtitle": "请登录以继续。",
+    "identifier": "邮箱或手机号",
+    "password": "密码",
+    "remember": "记住我",
+    "signUpNow": "立即注册",
+    "login": {
+      "noAccount": "还没有账号？",
+      "forgotPassword": "忘记密码？"
+    },
+    "signingIn": "正在登录…"
+  },
   "common": {
     "collapse": "收起",
     "backToList": "返回列表",


### PR DESCRIPTION
…om/v2/chat/completions，自动在 Header 里带 Authorization: Bearer

    <API Key>，必要时携带 appid；如果配置仍指向旧域名则回退到 /rpc/2.0/.../?access_token= 逻辑，同时兼容流式/非流式响应的新旧格式，并加了模型 ID 映射与错误提
    示。
  - Provider manifest backend/config/agents/providers.d/baidu_wenxin.yaml 更新默认 BaseURL 为 v2，并扩充模型列表（含 ERNIE Lite/Tiny/Speed/4.0 等），方便管理 台直接选择，包括免费 Lite 版本。
  - 新增 docs/guides/agent/ai_setting.md 说明后台保存/激活流程：默认配置来源、如何持久化多 provider 凭据、以及必须“切换后点保存”才能更新 ai_route_policies 的 主模型，附带常见问题排查。