### PR TITLE
• 本次 Agent Chat 相关实现/修改总结（Comment）

### DIFF
--- a/backend/config/agents/providers.d/comfyui.yaml
+++ b/backend/config/agents/providers.d/comfyui.yaml
@@ -1,0 +1,29 @@
+id: comfyui
+name: ComfyUI
+aliases: ["Comfy UI", "comfy-ui", "Stable Diffusion (ComfyUI)"]
+
+drivers:
+  # 目前后端 image driver 仍在演进，这里先用 external 占位，确保 UI 可选
+  image: external
+  video: external
+
+# ComfyUI 常见为本地服务，无鉴权；若你有反代鉴权，可在 UI 里配 base_url + api_key 并由网关处理。
+auth:
+  scheme: none
+  fields: ["base_url"]
+  defaults:
+    base_url: "http://127.0.0.1:8188"
+
+modalities:
+  image:
+    note: "ComfyUI Image（UI 目录占位）。实际调用需接入 external/image driver。"
+    models:
+      - id: sdxl
+        label: "SDXL (ComfyUI)"
+        tags: ["image","sd","comfyui","placeholder"]
+      - id: flux
+        label: "FLUX (ComfyUI)"
+        tags: ["image","comfyui","placeholder"]
+  video:
+    note: "ComfyUI Video（UI 目录占位）。"
+    models: []

--- a/backend/config/agents/providers.d/hunyuan.yaml
+++ b/backend/config/agents/providers.d/hunyuan.yaml
@@ -1,0 +1,128 @@
+id: hunyuan
+name: 腾讯混元 (Hunyuan)
+aliases:
+  # “元宝”是产品侧名称，这里作为别名兼容历史配置/输入
+  - "Hunyuan"
+  - "hunyuan"
+  - "腾讯混元"
+  - "Tencent Hunyuan"
+  - "Yuanbao"
+  - "yuanbao"
+  - "腾讯元宝"
+  - "Tencent Yuanbao"
+
+drivers:
+  llm: hunyuan
+  image: external
+  video: external
+
+auth:
+  # 同时支持两种接入方式：
+  # 1) OpenAI SDK 兼容：API KEY（优先推荐，前端默认）
+  # 2) 腾讯云 SDK：SecretId/SecretKey（TC3 签名）
+  modes:
+    - id: openai
+      label: "OpenAI SDK（API Key）"
+      scheme: bearer
+      fields: ["api_key", "base_url"]
+      defaults:
+        # 腾讯云大模型 API（OpenAI SDK 兼容）
+        base_url: "https://api.hunyuan.cloud.tencent.com/v1"
+    - id: tc3
+      label: "腾讯云 SDK（SecretId/SecretKey）"
+      scheme: tc3
+      fields: ["secret_id", "secret_key", "region", "base_url"]
+      defaults:
+        base_url: "https://hunyuan.tencentcloudapi.com"
+        region: "ap-guangzhou"
+
+modalities:
+  llm:
+    note: "目录占位：用于在 UI 中预置混元模型列表；实际调用需要补齐 llm driver（或接入 OpenAI-compatible 网关）。"
+    models:
+      - id: hunyuan-lite
+        label: "混元 Lite (placeholder)"
+        tags: ["llm","tencent","placeholder"]
+        defaults:
+          temperature: 0.7
+          max_tokens: 1024
+          # OpenAI SDK 模式的 base_url 默认带 /v1，因此这里用相对路径
+          api_path: "/chat/completions"
+      - id: hunyuan-standard
+        label: "混元 Standard (placeholder)"
+        tags: ["llm","tencent","placeholder"]
+        defaults:
+          temperature: 0.7
+          max_tokens: 2048
+          api_path: "/chat/completions"
+      - id: hunyuan-standard-256K
+        label: "混元 Standard 256K (placeholder)"
+        tags: ["llm","tencent","placeholder","long-context"]
+        defaults:
+          temperature: 0.6
+          max_tokens: 4096
+          api_path: "/chat/completions"
+      - id: hunyuan-turbo
+        label: "混元 Turbo (placeholder)"
+        tags: ["llm","tencent","placeholder"]
+        defaults:
+          temperature: 0.7
+          max_tokens: 1024
+          api_path: "/chat/completions"
+      - id: hunyuan-turbo-latest
+        label: "混元 Turbo Latest (placeholder)"
+        tags: ["llm","tencent","placeholder"]
+        defaults:
+          temperature: 0.7
+          max_tokens: 1024
+          api_path: "/chat/completions"
+      - id: hunyuan-pro
+        label: "混元 Pro (placeholder)"
+        tags: ["llm","tencent","placeholder"]
+        defaults:
+          temperature: 0.6
+          max_tokens: 2048
+          api_path: "/chat/completions"
+      - id: hunyuan-code
+        label: "混元 Code (placeholder)"
+        tags: ["llm","tencent","placeholder","code"]
+        defaults:
+          temperature: 0.3
+          max_tokens: 2048
+          api_path: "/chat/completions"
+
+  model3d:
+    note: "腾讯混元 3D 生成模型（UI 目录）。"
+    models:
+      - id: HY-3D-Express
+        label: "HY-3D-Express"
+        tags: ["3d","tencent","hunyuan"]
+      - id: HY-3D-UVWrap-1.5
+        label: "HY-3D-UVWrap-1.5"
+        tags: ["3d","tencent","hunyuan"]
+      - id: HY 3D Texture Generation
+        label: "HY 3D Texture Generation"
+        tags: ["3d","tencent","hunyuan","texture"]
+      - id: HY 3D Smart Topology
+        label: "HY 3D Smart Topology"
+        tags: ["3d","tencent","hunyuan","topology"]
+      - id: HY 3D Part Generation
+        label: "HY 3D Part Generation"
+        tags: ["3d","tencent","hunyuan","part"]
+      - id: HY-3D-Profession
+        label: "HY-3D-Profession"
+        tags: ["3d","tencent","hunyuan"]
+
+  image:
+    note: "目录占位：用于在 UI 中预置混元图像生成入口；实际调用需要补齐 image driver。"
+    models:
+      - id: hunyuan-image
+        label: "混元 图像生成 (placeholder)"
+        tags: ["image","tencent","placeholder"]
+
+  video:
+    note: "目录占位：用于在 UI 中预置混元视频生成入口；实际调用需要补齐 video driver。"
+    models:
+      - id: hunyuan-video
+        label: "混元 视频生成 (placeholder)"
+        tags: ["video","tencent","placeholder"]

--- a/backend/config/agents/providers.d/openai.yaml
+++ b/backend/config/agents/providers.d/openai.yaml
@@ -101,7 +101,14 @@ modalities:
         tags: ["audio","asr","legacy"]
 
   video:
-    models: []   # 目前无公开 API 可用的视频生成模型；留空以便后续补齐
+    # 预置 UI 可选项（部分环境通过网关/代理支持）
+    models:
+      - id: sora
+        label: "Sora"
+        tags: ["video","gen","placeholder"]
+      - id: sora-preview
+        label: "Sora Preview"
+        tags: ["video","gen","placeholder"]
 
   rerank:
     models: []   # OpenAI 暂无独立 rerank 模型；通常用 LLM/Embedding 组合处理

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -30,6 +30,10 @@ func InitGlobalConfig(configPath string) error {
 		return fmt.Errorf("解析配置文件失败: %w", err)
 	}
 
+	// AI: default fill + global snapshot (read-only)
+	config.AI.SetDefaults()
+	agentCfg.SetGlobalAIConfig(&config.AI)
+
 	GlobalConfig = &config
 	return nil
 }

--- a/backend/internal/server/agent/catalog/registry.go
+++ b/backend/internal/server/agent/catalog/registry.go
@@ -35,9 +35,18 @@ type Manifest struct {
 }
 
 type AuthSpec struct {
-	Scheme   string            `yaml:"scheme" json:"scheme"`                         // bearer|aksk|oauth2|...
+	Scheme   string            `yaml:"scheme" json:"scheme"`                         // bearer|aksk|oauth2|tc3|...
 	Fields   []string          `yaml:"fields,omitempty" json:"fields,omitempty"`     // ["api_key","base_url",...]
-	Defaults map[string]string `yaml:"defaults,omitempty" json:"defaults,omitempty"` // e.g. {"base_url": "https://api.openai.com/v1"}
+	Defaults map[string]string `yaml:"defaults,omitempty" json:"defaults,omitempty"` // e.g. {"base_url": "https://api.openai.com"}
+	Modes    []AuthModeSpec    `yaml:"modes,omitempty" json:"modes,omitempty"`       // optional multi-mode auth
+}
+
+type AuthModeSpec struct {
+	ID       string            `yaml:"id" json:"id"`
+	Label    string            `yaml:"label,omitempty" json:"label,omitempty"`
+	Scheme   string            `yaml:"scheme" json:"scheme"`
+	Fields   []string          `yaml:"fields,omitempty" json:"fields,omitempty"`
+	Defaults map[string]string `yaml:"defaults,omitempty" json:"defaults,omitempty"`
 }
 
 type ModalityManifest struct {
@@ -171,6 +180,9 @@ func NormalizeModality(s string) string {
 	// Video
 	case "video", "vid", "视频", "视频生成":
 		return "video"
+	// 3D Model Generation
+	case "model3d", "3d", "3d生成", "3d 生成", "3d模型", "3d模型生成", "模型3d", "模型3d生成":
+		return "model3d"
 	// Audio（预留）
 	case "audio", "speech", "声音", "语音":
 		return "audio"

--- a/backend/internal/server/agent/config/ai.go
+++ b/backend/internal/server/agent/config/ai.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/ArtisanCloud/PowerX/internal/server/agent/catalog"
+	"sync/atomic"
 	"time"
 )
 
@@ -16,6 +17,29 @@ type AIConfig struct {
 
 	// 路由/缓存/容错（可选）
 	Routing AIRouting `yaml:"routing" mapstructure:"routing"`
+}
+
+// ---------- Global AI Config (read-only snapshot) ----------
+//
+// 用于在运行时（service/handler）读取 config.yaml 里的 ai.defaults 兜底，
+// 避免在 service 层引入顶层 config 包导致循环依赖。
+var globalAIConfig atomic.Value // stores *AIConfig
+
+func SetGlobalAIConfig(cfg *AIConfig) {
+	if cfg == nil {
+		return
+	}
+	// 存一份指针快照（只读使用）
+	globalAIConfig.Store(cfg)
+}
+
+func GetGlobalAIConfig() *AIConfig {
+	if v := globalAIConfig.Load(); v != nil {
+		if cfg, ok := v.(*AIConfig); ok {
+			return cfg
+		}
+	}
+	return nil
 }
 
 // ---------- Defaults ----------

--- a/backend/internal/server/agent/contract/types.go
+++ b/backend/internal/server/agent/contract/types.go
@@ -12,6 +12,7 @@ const (
 	ModAudioTTS Modality = "audio_tts"
 	ModAudioASR Modality = "audio_asr"
 	ModVideo    Modality = "video"
+	ModModel3D  Modality = "model3d"
 	ModRerank   Modality = "rerank"
 )
 

--- a/backend/internal/server/agent/drivers/eino/agent.go
+++ b/backend/internal/server/agent/drivers/eino/agent.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	config2 "github.com/ArtisanCloud/PowerX/internal/server/agent/drivers/eino/config"
 	"github.com/ArtisanCloud/PowerX/pkg/utils"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +18,7 @@ import (
 	agentschema "github.com/ArtisanCloud/PowerX/internal/server/agent/schemas"
 	"github.com/ArtisanCloud/PowerX/pkg/corex/flow/loader"
 	flowschema "github.com/ArtisanCloud/PowerX/pkg/corex/flow/schemas"
+	"github.com/ArtisanCloud/PowerX/pkg/dto"
 
 	"github.com/cloudwego/eino/schema"
 )
@@ -409,6 +411,26 @@ func (a *AgentClient) Stream(ctx context.Context, flowID string, params flowsche
 	sr, sw := agent.NewResultPipe(16)
 	go func() {
 		defer sw.Close()
+		defer func() {
+			if r := recover(); r != nil {
+				err := fmt.Errorf("panic in stream: %v", r)
+				_ = sw.Send(nil, err)
+				fin := time.Now().UTC()
+				a.setStatus(execID, &agentschema.ExecutionStatus{
+					PlanID:      execID,
+					Status:      "failed",
+					Progress:    0,
+					CurrentStep: "panic",
+					StartedAt:   a.getStart(execID),
+					CompletedAt: &fin,
+					Error:       err.Error(),
+					Metadata: map[string]any{
+						"flow_id": flowID,
+						"stack":   string(debug.Stack()),
+					},
+				})
+			}
+		}()
 
 		_ = sw.Send(&agentschema.ExecutionResult{
 			Success:   true,
@@ -656,7 +678,19 @@ func execLLM(a *AgentClient) NodeExec {
 		}
 
 		// 2) client & config
-		mc := config2.MergeConfig(a.config.LLMConfig, nil)
+		if a == nil || a.config == nil {
+			return nil, fmt.Errorf("llm config missing: agent client not initialized")
+		}
+		mc, err := resolveLLMConfig(node, in, a)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(mc.Provider) == "" {
+			return nil, fmt.Errorf("llm config missing provider")
+		}
+		if strings.TrimSpace(mc.Model) == "" {
+			return nil, fmt.Errorf("llm config missing model")
+		}
 		cli, err := llm.NewClient(mc.Provider)
 		if err != nil {
 			return nil, fmt.Errorf("llm provider init failed: %w", err)
@@ -678,7 +712,7 @@ func execLLM(a *AgentClient) NodeExec {
 			// 5) 原生流不可用 -> 回退到同步 + 本地分块回放
 			content, invErr := cli.Invoke(ctx, mc, prompt)
 			if invErr != nil {
-				return flowschema.Result{"content": "", "llm_error": invErr.Error()}, nil
+				return nil, fmt.Errorf("llm invoke failed: %w", invErr)
 			}
 
 			// 分块配置：优先节点参数，可不配就用默认
@@ -717,10 +751,179 @@ func execLLM(a *AgentClient) NodeExec {
 		// 6) 上层不需要流式 -> 直接同步调用
 		content, err := cli.Invoke(ctx, mc, prompt)
 		if err != nil {
-			return flowschema.Result{"content": "", "llm_error": err.Error()}, nil
+			return nil, fmt.Errorf("llm invoke failed: %w", err)
 		}
 		return flowschema.Result{"content": content}, nil
 	}
+}
+
+func resolveLLMConfig(node *flowschema.Node, in flowschema.Context, a *AgentClient) (*config2.ModelConfig, error) {
+	// Priority (low -> high):
+	// 1) driver-level fallback: agent.llm (config.yaml) —— 仅用于“调用方未注入 config”的兜底
+	// 2) runtime request: dto.ChatConfig (in["config"]) —— 通常已包含「AI settings 默认 + Agent 自身配置 + 本次请求覆盖」
+	// 3) node params overrides —— 节点级最高优先级
+	var mc *config2.ModelConfig
+
+	// 2) runtime request config (ChatConfig)
+	if in != nil {
+		if v := in["config"]; v != nil {
+			switch vv := v.(type) {
+			case *dto.ChatConfig:
+				mc = config2.MergeConfig(mc, modelConfigFromChatConfig(vv))
+			case dto.ChatConfig:
+				tmp := vv
+				mc = config2.MergeConfig(mc, modelConfigFromChatConfig(&tmp))
+			case map[string]any:
+				mc = config2.MergeConfig(mc, modelConfigFromChatConfig(mapToChatConfig(vv)))
+			}
+		}
+	}
+
+	// 1) driver-level fallback (only when caller didn't inject config)
+	if mc == nil && a != nil && a.config != nil {
+		mc = config2.MergeConfig(mc, a.config.LLMConfig)
+	}
+
+	// 3) node params overrides
+	if node != nil && len(node.Params) > 0 {
+		mc = config2.MergeConfig(mc, modelConfigFromNodeParams(node.Params))
+	}
+
+	if mc == nil {
+		return nil, fmt.Errorf("llm config missing")
+	}
+	return mc, nil
+}
+
+func modelConfigFromChatConfig(c *dto.ChatConfig) *config2.ModelConfig {
+	if c == nil {
+		return nil
+	}
+	return &config2.ModelConfig{
+		Provider:     strings.TrimSpace(c.Provider),
+		Endpoint:     strings.TrimSpace(c.Endpoint),
+		APIKey:       strings.TrimSpace(c.APIKey),
+		Model:        strings.TrimSpace(c.ModelName),
+		SystemPrompt: strings.TrimSpace(c.SystemPrompt),
+		Temperature:  c.Temperature,
+		MaxTokens:    c.MaxTokens,
+	}
+}
+
+func mapToChatConfig(m map[string]any) *dto.ChatConfig {
+	if m == nil {
+		return nil
+	}
+	getStr := func(key string) string {
+		if v, ok := m[key]; ok {
+			if s, ok2 := v.(string); ok2 {
+				return s
+			}
+		}
+		return ""
+	}
+	getF := func(key string) float64 {
+		if v, ok := m[key]; ok {
+			switch vv := v.(type) {
+			case float64:
+				return vv
+			case float32:
+				return float64(vv)
+			case int:
+				return float64(vv)
+			case int64:
+				return float64(vv)
+			}
+		}
+		return 0
+	}
+	getI := func(key string) int {
+		if v, ok := m[key]; ok {
+			switch vv := v.(type) {
+			case int:
+				return vv
+			case int64:
+				return int(vv)
+			case float64:
+				return int(vv)
+			}
+		}
+		return 0
+	}
+	return &dto.ChatConfig{
+		ModelName:    strings.TrimSpace(getStr("model_name")),
+		Provider:     strings.TrimSpace(getStr("provider")),
+		Endpoint:     strings.TrimSpace(getStr("endpoint")),
+		APIKey:       strings.TrimSpace(getStr("api_key")),
+		Temperature:  getF("temperature"),
+		MaxTokens:    getI("max_tokens"),
+		SystemPrompt: strings.TrimSpace(getStr("system_prompt")),
+	}
+}
+
+func modelConfigFromNodeParams(params map[string]any) *config2.ModelConfig {
+	if params == nil {
+		return nil
+	}
+	out := &config2.ModelConfig{}
+
+	setStr := func(dst *string, keys ...string) {
+		for _, k := range keys {
+			if v, ok := params[k]; ok {
+				if s, ok2 := v.(string); ok2 && strings.TrimSpace(s) != "" {
+					*dst = strings.TrimSpace(s)
+					return
+				}
+			}
+		}
+	}
+	setFloat := func(dst *float64, keys ...string) {
+		for _, k := range keys {
+			if v, ok := params[k]; ok {
+				switch vv := v.(type) {
+				case float64:
+					*dst = vv
+					return
+				case float32:
+					*dst = float64(vv)
+					return
+				case int:
+					*dst = float64(vv)
+					return
+				case int64:
+					*dst = float64(vv)
+					return
+				}
+			}
+		}
+	}
+	setInt := func(dst *int, keys ...string) {
+		for _, k := range keys {
+			if v, ok := params[k]; ok {
+				switch vv := v.(type) {
+				case int:
+					*dst = vv
+					return
+				case int64:
+					*dst = int(vv)
+					return
+				case float64:
+					*dst = int(vv)
+					return
+				}
+			}
+		}
+	}
+
+	setStr(&out.Provider, "provider", "llm_provider")
+	setStr(&out.Endpoint, "endpoint", "base_url", "llm_endpoint")
+	setStr(&out.APIKey, "api_key", "apikey", "llm_api_key")
+	setStr(&out.Model, "model", "model_name", "llm_model")
+	setStr(&out.SystemPrompt, "system_prompt", "prompt_system")
+	setFloat(&out.Temperature, "temperature", "temp")
+	setInt(&out.MaxTokens, "max_tokens", "maxTokens")
+
+	return out
 }
 
 // 子工作流：use 或 params.flow_id 指定子 flow

--- a/backend/internal/server/agent/drivers/eino/agent_test.go
+++ b/backend/internal/server/agent/drivers/eino/agent_test.go
@@ -1,0 +1,150 @@
+package eino
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ArtisanCloud/PowerX/internal/server/agent/config"
+	einoCfg "github.com/ArtisanCloud/PowerX/internal/server/agent/drivers/eino/config"
+	agentschema "github.com/ArtisanCloud/PowerX/internal/server/agent/schemas"
+	flowschema "github.com/ArtisanCloud/PowerX/pkg/corex/flow/schemas"
+	"github.com/ArtisanCloud/PowerX/pkg/dto"
+)
+
+func TestExecLLM_MissingLLMConfigDoesNotPanic(t *testing.T) {
+	a := &AgentClient{
+		config: &config.AgentConfig{
+			LLMConfig: nil,
+		},
+	}
+
+	node := &flowschema.Node{
+		Kind:   flowschema.KindLLM,
+		Params: map[string]any{},
+	}
+	in := flowschema.Context{"message": "hello"}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+
+	_, err := execLLM(a)(context.Background(), a, "base_flow", node, in, agentschema.ExecutionMeta{})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveLLMConfig_PriorityOrder(t *testing.T) {
+	a := &AgentClient{
+		config: &config.AgentConfig{
+			LLMConfig: &einoCfg.ModelConfig{
+				Provider: "hunyuan",
+				Model:    "agent-model",
+			},
+		},
+	}
+
+	node := &flowschema.Node{
+		Kind: flowschema.KindLLM,
+		Params: map[string]any{
+			"model": "node-model",
+		},
+	}
+	in := flowschema.Context{
+		"message": "hello",
+		"config": &dto.ChatConfig{
+			Provider:  "ollama",
+			ModelName: "req-model",
+		},
+	}
+
+	mc, err := resolveLLMConfig(node, in, a)
+	if err != nil {
+		t.Fatalf("resolveLLMConfig: %v", err)
+	}
+	// node params highest: model from node, provider from request
+	if mc.Provider != "ollama" {
+		t.Fatalf("provider mismatch: %s", mc.Provider)
+	}
+	if mc.Model != "node-model" {
+		t.Fatalf("model mismatch: %s", mc.Model)
+	}
+}
+
+func TestStream_ExecutorPanicIsRecovered(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	// NewAgentClient 需要目录存在
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Fatalf("mkdir temp dir: %v", err)
+	}
+
+	cli, err := NewAgentClient(&config.AgentConfig{
+		FlowSpec: config.FlowSpecConfig{
+			BusinessDir: tmpDir,
+		},
+		LLMConfig: nil,
+	})
+	if err != nil {
+		t.Fatalf("NewAgentClient: %v", err)
+	}
+	a := cli.(*AgentClient)
+
+	// 注入一个会 panic 的 executor
+	a.execMu.Lock()
+	a.kindExecs["panic"] = func(ctx context.Context, a *AgentClient, curFlowID string, node *flowschema.Node, in flowschema.Context, meta agentschema.ExecutionMeta) (flowschema.Result, error) {
+		panic("boom")
+	}
+	a.execMu.Unlock()
+
+	// 缓存一个包含 panic 节点的 flow，绕过 resolver
+	a.flowMu.Lock()
+	a.flowCache["panic_flow"] = &flowschema.Flow{
+		FlowID: "panic_flow",
+		Nodes: []*flowschema.Node{
+			{Kind: flowschema.NodeKind("panic"), Params: map[string]any{}},
+		},
+	}
+	a.flowMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	sr, err := a.Stream(ctx, "panic_flow", flowschema.Context{"message": "hi"}, agentschema.ExecutionMeta{RequestID: "test"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer sr.Close()
+
+	// 先读 start
+	_, err = sr.Recv()
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("unexpected error before panic: %v", err)
+	}
+
+	// 随后应该收到 panic 转换成的 error（而不是进程崩溃）
+	for {
+		_, recvErr := sr.Recv()
+		if errors.Is(recvErr, io.EOF) {
+			t.Fatalf("expected panic error, got EOF")
+		}
+		if recvErr == nil {
+			continue
+		}
+		if !strings.Contains(recvErr.Error(), "panic in stream") {
+			t.Fatalf("unexpected error: %v", recvErr)
+		}
+		break
+	}
+}

--- a/backend/internal/server/agent/drivers/eino/config/config.go
+++ b/backend/internal/server/agent/drivers/eino/config/config.go
@@ -9,6 +9,9 @@ type ModelConfig struct {
 	Provider     string         `yaml:"provider" json:"provider"`
 	Endpoint     string         `yaml:"endpoint" json:"endpoint"`
 	APIKey       string         `yaml:"api_key" json:"api_key"`
+	SecretID     string         `yaml:"secret_id" json:"secret_id"`
+	SecretKey    string         `yaml:"secret_key" json:"secret_key"`
+	Region       string         `yaml:"region" json:"region"`
 	Model        string         `yaml:"model" json:"model"`
 	SystemPrompt string         `yaml:"system_prompt" json:"system_prompt"`
 	Temperature  float64        `yaml:"temperature" json:"temperature"`
@@ -32,16 +35,61 @@ type ModelConfig struct {
 // ——— 配置融合 ———
 // 以 Agent 默认配置为“底”，运行时覆盖它（req.Config > agent cfg）
 func MergeConfig(base *ModelConfig, override *ModelConfig) *ModelConfig {
-	out := base
+	out := &ModelConfig{}
+	if base != nil {
+		*out = *base
+	}
 	if override == nil {
 		return out
 	}
+	// string fields
 	if override.Provider != "" {
 		out.Provider = override.Provider
+	}
+	if override.Endpoint != "" {
+		out.Endpoint = override.Endpoint
+	}
+	if override.APIKey != "" {
+		out.APIKey = override.APIKey
+	}
+	if override.SecretID != "" {
+		out.SecretID = override.SecretID
+	}
+	if override.SecretKey != "" {
+		out.SecretKey = override.SecretKey
+	}
+	if override.Region != "" {
+		out.Region = override.Region
 	}
 	if override.Model != "" {
 		out.Model = override.Model
 	}
+	if override.SystemPrompt != "" {
+		out.SystemPrompt = override.SystemPrompt
+	}
+	if override.Organization != "" {
+		out.Organization = override.Organization
+	}
+	if override.AzureDeployment != "" {
+		out.AzureDeployment = override.AzureDeployment
+	}
+	if override.APIVersion != "" {
+		out.APIVersion = override.APIVersion
+	}
+	if override.APIType != "" {
+		out.APIType = override.APIType
+	}
+	if override.AccessToken != "" {
+		out.AccessToken = override.AccessToken
+	}
+	if override.BaiduAK != "" {
+		out.BaiduAK = override.BaiduAK
+	}
+	if override.BaiduSK != "" {
+		out.BaiduSK = override.BaiduSK
+	}
+
+	// numeric fields (0 usually means "unspecified" in this project)
 	if override.Temperature > 0 {
 		out.Temperature = override.Temperature
 	}
@@ -50,6 +98,19 @@ func MergeConfig(base *ModelConfig, override *ModelConfig) *ModelConfig {
 	}
 	if override.TopP > 0 {
 		out.TopP = override.TopP
+	}
+	if override.Timeout > 0 {
+		out.Timeout = override.Timeout
+	}
+
+	// maps
+	if len(override.Extra) > 0 {
+		if out.Extra == nil {
+			out.Extra = map[string]any{}
+		}
+		for k, v := range override.Extra {
+			out.Extra[k] = v
+		}
 	}
 	return out
 }

--- a/backend/internal/server/agent/drivers/eino/llm/factory.go
+++ b/backend/internal/server/agent/drivers/eino/llm/factory.go
@@ -1,12 +1,17 @@
 package llm
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // NewClient：按 provider 返回具体实现（都满足 LLMClient）
 func NewClient(provider string) (LLMClient, error) {
 	switch normalize(provider) {
 	case "openai":
 		return NewOpenAIClient(), nil
+	case "hunyuan":
+		return NewHunyuanClient(), nil
 	case "ollama":
 		return NewOllamaClient(), nil
 	case "baidu", "qianfan":
@@ -18,6 +23,14 @@ func NewClient(provider string) (LLMClient, error) {
 }
 
 func normalize(s string) string {
-	// 简单归一化，省略实现
-	return s
+	p := strings.ToLower(strings.TrimSpace(s))
+	if p == "" {
+		return ""
+	}
+	// OpenAI-compatible providers → reuse openai client
+	switch p {
+	case "openrouter", "vllm", "deepseek", "moonshot":
+		return "openai"
+	}
+	return p
 }

--- a/backend/internal/server/agent/drivers/eino/llm/hunyuan.go
+++ b/backend/internal/server/agent/drivers/eino/llm/hunyuan.go
@@ -1,0 +1,263 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ArtisanCloud/PowerX/internal/server/agent/drivers/eino/config"
+)
+
+// 腾讯云 混元（Hunyuan）LLM：TC3-HMAC-SHA256 签名 + ChatCompletions
+// 参考：腾讯云通用 API 签名（TC3）与 Hunyuan ChatCompletions 接口。
+type hunyuanClient struct{ NoopStream }
+
+func NewHunyuanClient() LLMClient { return &hunyuanClient{} }
+
+const (
+	defaultHunyuanEndpoint = "https://hunyuan.tencentcloudapi.com"
+	hunyuanServiceName     = "hunyuan"
+	hunyuanVersion         = "2023-09-01"
+	hunyuanAction          = "ChatCompletions"
+	hunyuanAlgorithm       = "TC3-HMAC-SHA256"
+)
+
+type hunyuanMessage struct {
+	Role    string `json:"Role"`
+	Content string `json:"Content"`
+}
+
+type hunyuanChatReq struct {
+	Model       string           `json:"Model"`
+	Messages    []hunyuanMessage `json:"Messages"`
+	Temperature *float64         `json:"Temperature,omitempty"`
+	TopP        *float32         `json:"TopP,omitempty"`
+	MaxTokens   *int             `json:"MaxTokens,omitempty"`
+	Stream      bool             `json:"Stream,omitempty"`
+}
+
+type hunyuanChatResp struct {
+	Response struct {
+		Error *struct {
+			Code    string `json:"Code"`
+			Message string `json:"Message"`
+		} `json:"Error,omitempty"`
+		Choices []struct {
+			Message struct {
+				Role    string `json:"Role"`
+				Content string `json:"Content"`
+			} `json:"Message"`
+		} `json:"Choices"`
+		RequestId string `json:"RequestId"`
+	} `json:"Response"`
+}
+
+func (c *hunyuanClient) Invoke(ctx context.Context, mc *config.ModelConfig, prompt string) (string, error) {
+	if mc == nil {
+		return "", errors.New("hunyuan: missing model config")
+	}
+	if strings.TrimSpace(mc.SecretID) == "" || strings.TrimSpace(mc.SecretKey) == "" {
+		return "", errors.New("hunyuan: missing secret_id/secret_key")
+	}
+
+	endpoint := strings.TrimSpace(mc.Endpoint)
+	if endpoint == "" {
+		endpoint = defaultHunyuanEndpoint
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("hunyuan: invalid base_url: %s", endpoint)
+	}
+	host := u.Host
+
+	region := strings.TrimSpace(mc.Region)
+	if region == "" {
+		region = "ap-guangzhou"
+	}
+
+	reqBody := hunyuanChatReq{
+		Model: mc.Model,
+		Messages: []hunyuanMessage{
+			{Role: "system", Content: mc.SystemPrompt},
+			{Role: "user", Content: prompt},
+		},
+		Stream: false,
+	}
+	if mc.Temperature > 0 {
+		v := mc.Temperature
+		reqBody.Temperature = &v
+	}
+	if mc.TopP > 0 {
+		v := mc.TopP
+		reqBody.TopP = &v
+	}
+	if mc.MaxTokens > 0 {
+		v := mc.MaxTokens
+		reqBody.MaxTokens = &v
+	}
+
+	action := hunyuanAction
+	version := hunyuanVersion
+	if mc.Extra != nil {
+		if v, ok := mc.Extra["tc_action"].(string); ok && strings.TrimSpace(v) != "" {
+			action = strings.TrimSpace(v)
+		}
+		if v, ok := mc.Extra["tc_version"].(string); ok && strings.TrimSpace(v) != "" {
+			version = strings.TrimSpace(v)
+		}
+	}
+
+	callOnce := func(payload []byte) (*hunyuanChatResp, []byte, error) {
+		ts := time.Now().Unix()
+		auth, err := tc3Authorization(
+			hunyuanServiceName,
+			strings.TrimSpace(mc.SecretID),
+			strings.TrimSpace(mc.SecretKey),
+			host,
+			ts,
+			payload,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+		if err != nil {
+			return nil, nil, err
+		}
+		httpReq.Header.Set("Content-Type", "application/json; charset=utf-8")
+		httpReq.Header.Set("Accept", "application/json")
+		httpReq.Header.Set("Host", host)
+		httpReq.Header.Set("X-TC-Action", action)
+		httpReq.Header.Set("X-TC-Version", version)
+		httpReq.Header.Set("X-TC-Region", region)
+		httpReq.Header.Set("X-TC-Timestamp", strconv.FormatInt(ts, 10))
+		httpReq.Header.Set("Authorization", auth)
+
+		// 默认超时要覆盖常见对话时长；上层 ctx 仍会兜底取消（Engine 默认 10min）
+		client := &http.Client{Timeout: effectiveTimeout(mc.Timeout, 10*time.Minute)}
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, nil, err
+		}
+		defer resp.Body.Close()
+
+		bt, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+		if resp.StatusCode/100 != 2 {
+			return nil, bt, fmt.Errorf("hunyuan invoke status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(bt)))
+		}
+		var out hunyuanChatResp
+		if err := json.Unmarshal(bt, &out); err != nil {
+			return nil, bt, err
+		}
+		return &out, bt, nil
+	}
+
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", err
+	}
+	out, bt, err := callOnce(payload)
+	if err != nil {
+		return "", err
+	}
+	if out.Response.Error != nil {
+		// 兼容：部分账号/版本的 ChatCompletions 不接受 MaxTokens（会返回 UnknownParameter）。
+		// 这里对健康检查/简单调用做一次降级重试：去掉 MaxTokens 后再请求一次。
+		if reqBody.MaxTokens != nil &&
+			strings.EqualFold(strings.TrimSpace(out.Response.Error.Code), "UnknownParameter") &&
+			strings.Contains(out.Response.Error.Message, "MaxTokens") {
+			reqBody.MaxTokens = nil
+			payload2, e := json.Marshal(reqBody)
+			if e != nil {
+				return "", fmt.Errorf("hunyuan error code=%s message=%s", out.Response.Error.Code, out.Response.Error.Message)
+			}
+			out2, _, e2 := callOnce(payload2)
+			if e2 != nil {
+				return "", e2
+			}
+			if out2.Response.Error != nil {
+				return "", fmt.Errorf("hunyuan error code=%s message=%s", out2.Response.Error.Code, out2.Response.Error.Message)
+			}
+			if len(out2.Response.Choices) == 0 {
+				return "", errors.New("hunyuan: no choices")
+			}
+			return out2.Response.Choices[0].Message.Content, nil
+		}
+		return "", fmt.Errorf("hunyuan error code=%s message=%s", out.Response.Error.Code, out.Response.Error.Message)
+	}
+	_ = bt
+	if len(out.Response.Choices) == 0 {
+		return "", errors.New("hunyuan: no choices")
+	}
+	return out.Response.Choices[0].Message.Content, nil
+}
+
+func effectiveTimeout(v time.Duration, def time.Duration) time.Duration {
+	if v <= 0 {
+		return def
+	}
+	return v
+}
+
+func tc3Authorization(service, secretID, secretKey, host string, timestamp int64, payload []byte) (string, error) {
+	if secretID == "" || secretKey == "" {
+		return "", errors.New("tc3: missing secret")
+	}
+	t := time.Unix(timestamp, 0).UTC()
+	date := t.Format("2006-01-02")
+
+	hashedPayload := sha256Hex(payload)
+	canonicalHeaders := fmt.Sprintf("content-type:%s\nhost:%s\n", "application/json; charset=utf-8", host)
+	signedHeaders := "content-type;host"
+	canonicalRequest := strings.Join([]string{
+		http.MethodPost,
+		"/",
+		"",
+		canonicalHeaders,
+		signedHeaders,
+		hashedPayload,
+	}, "\n")
+
+	credentialScope := fmt.Sprintf("%s/%s/tc3_request", date, service)
+	stringToSign := strings.Join([]string{
+		hunyuanAlgorithm,
+		strconv.FormatInt(timestamp, 10),
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	signingKey := tc3SigningKey(secretKey, date, service)
+	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+
+	return fmt.Sprintf("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		hunyuanAlgorithm, secretID, credentialScope, signedHeaders, signature), nil
+}
+
+func tc3SigningKey(secretKey, date, service string) []byte {
+	kDate := hmacSHA256([]byte("TC3"+secretKey), []byte(date))
+	kService := hmacSHA256(kDate, []byte(service))
+	return hmacSHA256(kService, []byte("tc3_request"))
+}
+
+func hmacSHA256(key []byte, msg []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(msg)
+	return h.Sum(nil)
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/server/agent/drivers/eino/llm/llm.go
+++ b/backend/internal/server/agent/drivers/eino/llm/llm.go
@@ -30,6 +30,6 @@ type LLMClient interface {
 // 对“不支持流式”的 provider：嵌入 NoopStream 即可满足接口
 type NoopStream struct{}
 
-func (NoopStream) Stream(ctx context.Context, mc config.ModelConfig, prompt string, onDelta func(string)) (string, error) {
+func (NoopStream) Stream(ctx context.Context, mc *config.ModelConfig, prompt string, onDelta func(string)) (string, error) {
 	return "", ErrStreamNotSupported
 }

--- a/backend/internal/server/agent/drivers/eino/llm/openai.go
+++ b/backend/internal/server/agent/drivers/eino/llm/openai.go
@@ -41,6 +41,12 @@ type openAINonStreamResp struct {
 			Role    string `json:"role"`
 		} `json:"message"`
 	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type,omitempty"`
+		Code    any    `json:"code,omitempty"`
+		Param   any    `json:"param,omitempty"`
+	} `json:"error,omitempty"`
 }
 
 type openAIStreamDelta struct {
@@ -128,7 +134,9 @@ func (c *openaiClient) makeBody(mc *config.ModelConfig, userMessage string, stre
 func (c *openaiClient) httpClient(mc *config.ModelConfig) *http.Client {
 	to := mc.Timeout
 	if to <= 0 {
-		to = 30 * time.Second
+		// Chat/SSE 场景默认要足够长，避免“模型慢一点就被 30s 掐断”
+		// 由上层 ctx 超时兜底（Engine 默认 10min）。
+		to = 10 * time.Minute
 	}
 	return &http.Client{Timeout: to}
 }
@@ -154,17 +162,43 @@ func (c *openaiClient) Invoke(ctx context.Context, mc *config.ModelConfig, userM
 	}
 	defer resp.Body.Close()
 
+	bt, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode/100 != 2 {
-		bt, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("openai invoke status=%d body=%s", resp.StatusCode, string(bt))
+		return "", fmt.Errorf("openai invoke url=%s status=%d body=%s", url, resp.StatusCode, string(bt))
 	}
 
 	var jr openAINonStreamResp
-	if err := json.NewDecoder(resp.Body).Decode(&jr); err != nil {
-		return "", err
+	if err := json.Unmarshal(bt, &jr); err != nil {
+		return "", fmt.Errorf("openai decode failed: %w (body=%s)", err, string(bt))
+	}
+	if jr.Error != nil && strings.TrimSpace(jr.Error.Message) != "" {
+		return "", fmt.Errorf("openai error: %s", strings.TrimSpace(jr.Error.Message))
 	}
 	if len(jr.Choices) == 0 {
-		return "", errors.New("openai: no choices")
+		// 兼容诊断：部分 OpenAI-compatible 网关会返回腾讯云 TC3 风格结构（Response.Error.*）
+		// 此时 choices 为空但 StatusCode 可能仍为 2xx，容易误判为 “no choices”。
+		var tr struct {
+			Response struct {
+				Error *struct {
+					Code    string `json:"Code"`
+					Message string `json:"Message"`
+				} `json:"Error"`
+			} `json:"Response"`
+		}
+		if e := json.Unmarshal(bt, &tr); e == nil && tr.Response.Error != nil && strings.TrimSpace(tr.Response.Error.Message) != "" {
+			code := strings.TrimSpace(tr.Response.Error.Code)
+			msg := strings.TrimSpace(tr.Response.Error.Message)
+			if code != "" {
+				return "", fmt.Errorf("openai-compatible: unexpected tencent response url=%s code=%s message=%s", url, code, msg)
+			}
+			return "", fmt.Errorf("openai-compatible: unexpected tencent response url=%s message=%s", url, msg)
+		}
+
+		trim := string(bt)
+		if len(trim) > 2000 {
+			trim = trim[:2000] + "…"
+		}
+		return "", fmt.Errorf("openai: empty choices (url=%s body=%s)", url, trim)
 	}
 	return jr.Choices[0].Message.Content, nil
 }
@@ -274,6 +308,13 @@ func joinEndpoint(base, path string) string {
 	trimmed := strings.TrimRight(base, "/")
 	if trimmed == "" {
 		trimmed = base
+	}
+	// 兼容 OpenAI-compatible 网关：base_url 常见自带 /v1
+	// 若同时使用默认 path "/v1/..."，会拼出 "/v1/v1/..." 进而返回非预期 schema（choices 为空）。
+	if strings.HasSuffix(trimmed, "/v1") && strings.HasPrefix(path, "/v1/") {
+		path = strings.TrimPrefix(path, "/v1")
+	} else if strings.HasSuffix(trimmed, "/v1") && path == "/v1" {
+		path = ""
 	}
 	return trimmed + path
 }

--- a/backend/internal/server/agent/persistence/repository/agent_chat_message_repo.go
+++ b/backend/internal/server/agent/persistence/repository/agent_chat_message_repo.go
@@ -110,6 +110,18 @@ func (r *AgentChatMessageRepository) DeleteBySession(
 		Delete(&dbmodel.AgentChatMessage{}).Error
 }
 
+// DeleteAfterID：裁剪会话消息（删除 id > afterID 的所有消息）
+func (r *AgentChatMessageRepository) DeleteAfterID(
+	ctx context.Context, env string, tenantUUID *string, sessionID uint64, afterID uint64,
+) (int64, error) {
+	res := r.db.WithContext(ctx).
+		Scopes(dbmodel.WithScope(env, tenantUUID)).
+		Where("session_id = ?", sessionID).
+		Where("id > ?", afterID).
+		Delete(&dbmodel.AgentChatMessage{})
+	return res.RowsAffected, res.Error
+}
+
 // StatsBySession：汇总消息体积/令牌数
 type SessionMsgStats struct {
 	Count       int

--- a/backend/internal/server/agent/runtime/engine.go
+++ b/backend/internal/server/agent/runtime/engine.go
@@ -26,6 +26,12 @@ type Engine struct {
 func NewEngine() *Engine { return &Engine{mgr: agent.GetAgentManager()} }
 
 func (e *Engine) Run(ctx context.Context, msg string, reqCfg *dto.ChatConfig, explicitFlow string, sink EventSink) error {
+	// 统一超时：避免 LLM/下游卡死导致“前端永远生成中”
+	// - 目标体验是“不断开连接、持续可见”，但也要有上限兜底（默认 10 分钟）。
+	execTimeout := 10 * time.Minute
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
 	// 1) 多意图识别
 	tasks, err := e.mgr.DetectTasks(ctx, msg)
 	if err != nil {
@@ -67,7 +73,7 @@ func (e *Engine) Run(ctx context.Context, msg string, reqCfg *dto.ChatConfig, ex
 		"config":  reqCfg,
 	}, agentschema.ExecutionMeta{
 		RequestID: execID,
-		Timeout:   60,
+		Timeout:   execTimeout,
 		Metadata:  map[string]any{"transport": "engine"},
 	})
 	if err != nil {
@@ -76,40 +82,82 @@ func (e *Engine) Run(ctx context.Context, msg string, reqCfg *dto.ChatConfig, ex
 
 	// 4) 转发流事件
 	defer sr.Close()
+	type recvItem struct {
+		ch  *agentschema.ExecutionResult
+		err error
+	}
+	recvCh := make(chan recvItem, 1)
+
+	go func() {
+		defer close(recvCh)
+		for {
+			ch, err := sr.Recv()
+			recvCh <- recvItem{ch: ch, err: err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	hb := time.NewTicker(15 * time.Second)
+	defer hb.Stop()
+	lastRecvAt := time.Now()
+
 	for {
-		ch, err := sr.Recv()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
+		select {
+		case <-ctx.Done():
+			_ = sink.Emit(dto.EventError, map[string]any{"message": "请求超时或已取消", "detail": ctx.Err().Error()})
+			_ = sink.Emit(dto.EventEnd, map[string]any{"success": false})
+			return ctx.Err()
+		case <-hb.C:
+			// 心跳：让前端/网关确认连接仍然活着（前端可选择忽略，仅用于避免“看似挂死”）。
+			_ = sink.Emit(dto.EventHeartbeat, map[string]any{
+				"ts":           time.Now().UTC().Unix(),
+				"idle_seconds": int(time.Since(lastRecvAt).Seconds()),
+			})
+		case it, ok := <-recvCh:
+			if !ok {
 				_ = sink.Emit(dto.EventEnd, map[string]any{"success": true})
 				return nil
 			}
-			_ = sink.Emit(dto.EventError, map[string]any{"message": err.Error()})
-			_ = sink.Emit(dto.EventEnd, map[string]any{"success": false})
-			return err
-		}
+			if it.err != nil {
+				if errors.Is(it.err, io.EOF) {
+					_ = sink.Emit(dto.EventEnd, map[string]any{"success": true})
+					return nil
+				}
+				_ = sink.Emit(dto.EventError, map[string]any{"message": it.err.Error()})
+				_ = sink.Emit(dto.EventEnd, map[string]any{"success": false})
+				return it.err
+			}
+			lastRecvAt = time.Now()
+			ch := it.ch
+			if ch == nil {
+				continue
+			}
 
-		if delta, ok := ch.Metadata["delta_text"].(string); ok && delta != "" {
-			_ = sink.Emit(dto.EventToken, map[string]any{"delta": delta, "step_id": ch.StepID, "timestamp": ch.Timestamp})
-			continue
-		}
+			if delta, ok := ch.Metadata["delta_text"].(string); ok && delta != "" {
+				_ = sink.Emit(dto.EventToken, map[string]any{"delta": delta, "step_id": ch.StepID, "timestamp": ch.Timestamp})
+				continue
+			}
 
-		_ = sink.Emit(dto.EventData, map[string]any{
-			"success":   ch.Success,
-			"data":      ch.Data,
-			"step_id":   ch.StepID,
-			"timestamp": ch.Timestamp,
-			"metadata":  ch.Metadata,
-		})
-
-		if isFinal, _ := ch.Metadata["is_final"].(bool); isFinal {
-			_ = sink.Emit(dto.EventFinal, map[string]any{
+			_ = sink.Emit(dto.EventData, map[string]any{
 				"success":   ch.Success,
 				"data":      ch.Data,
-				"metadata":  ch.Metadata,
+				"step_id":   ch.StepID,
 				"timestamp": ch.Timestamp,
+				"metadata":  ch.Metadata,
 			})
-			_ = sink.Emit(dto.EventEnd, map[string]any{"success": true})
-			return nil
+
+			if isFinal, _ := ch.Metadata["is_final"].(bool); isFinal {
+				_ = sink.Emit(dto.EventFinal, map[string]any{
+					"success":   ch.Success,
+					"data":      ch.Data,
+					"metadata":  ch.Metadata,
+					"timestamp": ch.Timestamp,
+				})
+				_ = sink.Emit(dto.EventEnd, map[string]any{"success": true})
+				return nil
+			}
 		}
 	}
 }

--- a/backend/internal/service/agent/agent_setting_service.go
+++ b/backend/internal/service/agent/agent_setting_service.go
@@ -2,18 +2,25 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/ArtisanCloud/PowerX/internal/server/agent/catalog"
+	agentconf "github.com/ArtisanCloud/PowerX/internal/server/agent/config"
 	"github.com/ArtisanCloud/PowerX/internal/server/agent/contract"
 	agentcfg "github.com/ArtisanCloud/PowerX/internal/server/agent/drivers/eino/config"
 	agentllm "github.com/ArtisanCloud/PowerX/internal/server/agent/drivers/eino/llm"
 	dbmodel "github.com/ArtisanCloud/PowerX/internal/server/agent/persistence/model"
 	repoai "github.com/ArtisanCloud/PowerX/internal/server/agent/persistence/repository"
 	tenantrepo "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/repository/tenant"
+	settingrepo "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/repository/setting"
+	dbsetting "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/model/setting"
 	"github.com/ArtisanCloud/PowerX/pkg/corex/tenantkeys"
 	"github.com/ArtisanCloud/PowerX/pkg/utils"
 	"gorm.io/datatypes"
@@ -22,11 +29,22 @@ import (
 
 type ModelRule struct {
 	RequireAPIKey  bool
+	RequireSecretID  bool
+	RequireSecretKey bool
 	RequireBaseURL bool
 	DefaultBaseURL string
 }
 
-var sensitiveCredentialKeys = []string{"api_key", "secret", "client_secret", "access_token"}
+var sensitiveCredentialKeys = []string{"api_key", "secret_id", "secret_key", "secret", "client_secret", "access_token"}
+
+const TenantSettingKeyAICurrentEnv = "ai.current_env"
+const tenantSettingKeyAIProviderHealthPrefix = "ai.provider_health"
+
+type ProviderHealthRecord struct {
+	Status    string `json:"status"`    // healthy|unhealthy|unknown
+	CheckedAt int64  `json:"checkedAt"` // unix seconds
+	Message   string `json:"message"`   // error or "ok"
+}
 
 type AgentSettingService struct {
 	db         *gorm.DB
@@ -36,6 +54,7 @@ type AgentSettingService struct {
 	usageRepo  *repoai.AIUsageLogRepository
 	tks        *tenantkeys.TenantKeyService
 	tenantRepo *tenantrepo.TenantRepository
+	settingRepo *settingrepo.TenantSettingRepository
 }
 
 func NewAgentSettingService(db *gorm.DB) *AgentSettingService {
@@ -47,7 +66,136 @@ func NewAgentSettingService(db *gorm.DB) *AgentSettingService {
 		usageRepo:  repoai.NewAIUsageLogRepository(db),
 		tks:        tenantkeys.NewTenantKeyService(db),
 		tenantRepo: tenantrepo.NewTenantRepository(db),
+		settingRepo: settingrepo.NewTenantSettingRepository(db),
 	}
+}
+
+// ---------------- Tenant Current AI Env ----------------
+
+func (s *AgentSettingService) GetTenantCurrentAIEnv(
+	ctx context.Context, tenantUUID string,
+) (env string, configured bool, err error) {
+	out, err := s.settingRepo.GetByTenantAndKey(ctx, tenantUUID, TenantSettingKeyAICurrentEnv)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if out == nil || len(out.ValueJSON) == 0 {
+		return "", false, nil
+	}
+	var v string
+	if e := json.Unmarshal(out.ValueJSON, &v); e != nil {
+		return "", false, nil
+	}
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "", false, nil
+	}
+	return v, true, nil
+}
+
+func (s *AgentSettingService) SetTenantCurrentAIEnv(
+	ctx context.Context, tenantUUID string, env string,
+) error {
+	e := strings.TrimSpace(env)
+	if e == "" {
+		return fmt.Errorf("env 不能为空")
+	}
+	raw, _ := json.Marshal(e)
+	return s.settingRepo.Upsert(ctx, &dbsetting.TenantSetting{
+		TenantUUID: tenantUUID,
+		Key:        TenantSettingKeyAICurrentEnv,
+		ValueJSON:  datatypes.JSON(raw),
+		Group:      "ai",
+		Editable:   true,
+	})
+}
+
+// ---------------- Tenant Provider Health (per env+modality) ----------------
+
+func tenantProviderHealthKey(env string, modality string) string {
+	e := strings.TrimSpace(env)
+	m := strings.TrimSpace(strings.ToLower(modality))
+	if e == "" {
+		e = "default"
+	}
+	if m == "" {
+		m = "llm"
+	}
+	return fmt.Sprintf("%s.%s.%s", tenantSettingKeyAIProviderHealthPrefix, e, m)
+}
+
+func (s *AgentSettingService) GetTenantProviderHealthMap(
+	ctx context.Context, tenantUUID string, env string, modality string,
+) (map[string]ProviderHealthRecord, bool, error) {
+	key := tenantProviderHealthKey(env, modality)
+	out, err := s.settingRepo.GetByTenantAndKey(ctx, tenantUUID, key)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return map[string]ProviderHealthRecord{}, false, nil
+		}
+		return nil, false, err
+	}
+	if out == nil || len(out.ValueJSON) == 0 {
+		return map[string]ProviderHealthRecord{}, false, nil
+	}
+	var m map[string]ProviderHealthRecord
+	if e := json.Unmarshal(out.ValueJSON, &m); e != nil {
+		return map[string]ProviderHealthRecord{}, false, nil
+	}
+	if m == nil {
+		return map[string]ProviderHealthRecord{}, false, nil
+	}
+	// normalize keys
+	norm := map[string]ProviderHealthRecord{}
+	for k, v := range m {
+		p := strings.ToLower(strings.TrimSpace(k))
+		if p == "" {
+			continue
+		}
+		norm[p] = v
+	}
+	return norm, true, nil
+}
+
+func (s *AgentSettingService) UpsertTenantProviderHealth(
+	ctx context.Context, tenantUUID string, env string, modality string,
+	provider string, status string, message string,
+) error {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	if p == "" {
+		return fmt.Errorf("provider 不能为空")
+	}
+	key := tenantProviderHealthKey(env, modality)
+
+	m, _, err := s.GetTenantProviderHealthMap(ctx, tenantUUID, env, modality)
+	if err != nil {
+		return err
+	}
+	if m == nil {
+		m = map[string]ProviderHealthRecord{}
+	}
+	st := strings.ToLower(strings.TrimSpace(status))
+	switch st {
+	case "healthy", "unhealthy", "unknown":
+	default:
+		st = "unknown"
+	}
+	m[p] = ProviderHealthRecord{
+		Status:    st,
+		CheckedAt: time.Now().Unix(),
+		Message:   strings.TrimSpace(message),
+	}
+	raw, _ := json.Marshal(m)
+	return s.settingRepo.Upsert(ctx, &dbsetting.TenantSetting{
+		TenantUUID: tenantUUID,
+		Key:        key,
+		ValueJSON:  datatypes.JSON(raw),
+		Group:      "ai",
+		Editable:   true,
+	})
 }
 
 // ---------------- Providers / Models ----------------
@@ -72,6 +220,105 @@ func (s *AgentSettingService) Models(modality, provider string) ([]string, error
 	return out, nil
 }
 
+// ModelsForTenant：给 HTTP handler 用；针对 OpenRouter 支持远端拉取模型列表，失败则回退到本地 catalog。
+func (s *AgentSettingService) ModelsForTenant(
+	ctx context.Context,
+	env string,
+	tenantUUID *string,
+	modality string,
+	provider string,
+) ([]string, error) {
+	mod := strings.TrimSpace(strings.ToLower(modality))
+	prov := strings.TrimSpace(strings.ToLower(provider))
+
+	// OpenRouter：模型目录变化快，优先走远端 /models；失败则回退到本地目录（占位/示例）。
+	if prov == "openrouter" && (mod == "llm" || mod == "embedding") {
+		if remote, err := s.fetchOpenRouterModels(ctx, env, tenantUUID, mod); err == nil && len(remote) > 0 {
+			return remote, nil
+		}
+	}
+	return s.Models(mod, prov)
+}
+
+type openRouterModelsResponse struct {
+	Data   []struct{ ID string `json:"id"` } `json:"data"`
+	Models []struct{ ID string `json:"id"` } `json:"models"`
+}
+
+func (s *AgentSettingService) fetchOpenRouterModels(
+	ctx context.Context,
+	env string,
+	tenantUUID *string,
+	modality string,
+) ([]string, error) {
+	req := catalog.AuthReqFromCatalog("openrouter")
+	// 拉模型列表通常不要求 key，但如果已配置 key，我们也带上，避免账号维度过滤导致列表不全。
+	baseURL, apiKey, err := s.prepareAuthInputs(ctx, env, tenantUUID, "openrouter", "", "", true, req.DefaultBaseURL, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateEndpoint(baseURL); err != nil {
+		return nil, err
+	}
+
+	modelsURL := strings.TrimRight(baseURL, "/") + "/models"
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	r.Header.Set("Accept", "application/json")
+	if strings.TrimSpace(apiKey) != "" {
+		r.Header.Set("Authorization", "Bearer "+strings.TrimSpace(apiKey))
+	}
+	// OpenRouter 建议携带（可选）
+	r.Header.Set("X-Title", "PowerX")
+	// 部分场景下 OpenRouter 会建议提供来源（可选，但对某些网关/策略更友好）
+	r.Header.Set("HTTP-Referer", "https://powerx.local")
+
+	client := &http.Client{Timeout: 12 * time.Second}
+	resp, err := client.Do(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("openrouter models status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var out openRouterModelsResponse
+	if e := json.Unmarshal(body, &out); e != nil {
+		return nil, fmt.Errorf("openrouter models parse failed: %w (body=%s)", e, strings.TrimSpace(string(body)))
+	}
+
+	raw := out.Data
+	if len(raw) == 0 && len(out.Models) > 0 {
+		raw = out.Models
+	}
+
+	ids := make([]string, 0, len(raw))
+	seen := map[string]struct{}{}
+	for _, it := range raw {
+		id := strings.TrimSpace(it.ID)
+		if id == "" {
+			continue
+		}
+		// 轻度过滤：按模态做保守筛选（embedding 更偏向 openai/* embedding）
+		if strings.EqualFold(modality, "embedding") {
+			if !strings.Contains(strings.ToLower(id), "embedding") && !strings.HasSuffix(strings.ToLower(id), "-embed") {
+				// 不强过滤（很多 provider 不按 embedding 命名）；先放过
+			}
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
 func (s *AgentSettingService) tenantScopeKey(tenantUUID *string) string {
 	if tenantUUID == nil {
 		return ""
@@ -93,7 +340,7 @@ func (s *AgentSettingService) SaveCredentialAndProfile(
 	s.applyManifestToProfile(prof)
 
 	// 是否提交了新密钥？
-	sensKeys := []string{"api_key", "access_token", "client_secret", "secret"}
+	sensKeys := []string{"api_key", "secret_id", "secret_key", "access_token", "client_secret", "secret"}
 	hasNewSecret := false
 	for _, k := range sensKeys {
 		if v, _ := cred.Data[k].(string); strings.TrimSpace(v) != "" {
@@ -109,11 +356,58 @@ func (s *AgentSettingService) SaveCredentialAndProfile(
 
 	// 有新密钥则严格直连校验（只用这次入参，不读库）
 	if hasNewSecret {
-		if err := s.PingStrict(ctx, prof.Modality, prof.Provider, prof.Model,
-			baseURL,
-			utils.FirstJSONNonEmpty(cred.Data, sensKeys...),
-		); err != nil {
-			return fmt.Errorf("连通性校验失败: %w", err)
+		// LLM：真实连通性校验（会实际调用第三方）
+		if strings.EqualFold(prof.Modality, "llm") {
+			apiKey := ""
+			if v, _ := cred.Data["api_key"].(string); strings.TrimSpace(v) != "" {
+				apiKey = strings.TrimSpace(v)
+			}
+			secretID := ""
+			if v, _ := cred.Data["secret_id"].(string); strings.TrimSpace(v) != "" {
+				secretID = strings.TrimSpace(v)
+			}
+			secretKey := ""
+			if v, _ := cred.Data["secret_key"].(string); strings.TrimSpace(v) != "" {
+				secretKey = strings.TrimSpace(v)
+			}
+			region := ""
+			if v, _ := cred.Data["region"].(string); strings.TrimSpace(v) != "" {
+				region = strings.TrimSpace(v)
+			}
+			// 腾讯混元：支持两种接入方式（OpenAI SDK / 腾讯云 SDK）
+			if strings.EqualFold(strings.TrimSpace(prof.Provider), "hunyuan") {
+				mode := ""
+				if v, _ := cred.Data["auth_mode"].(string); strings.TrimSpace(v) != "" {
+					mode = strings.TrimSpace(v)
+				}
+				if err := s.PingHunyuan(ctx, env, tenantUUID, mode, prof.Model, baseURL, apiKey, secretID, secretKey, region); err != nil {
+					return fmt.Errorf("连通性校验失败: %w", err)
+				}
+			} else {
+				if err := s.PingStrict(ctx, prof.Modality, prof.Provider, prof.Model,
+					baseURL,
+					apiKey,
+					secretID,
+					secretKey,
+					region,
+				); err != nil {
+					return fmt.Errorf("连通性校验失败: %w", err)
+				}
+			}
+		} else {
+			// 非 LLM：目前只做结构校验（模型是否存在、base_url 是否合法、鉴权字段是否齐）
+			if err := s.PingGeneric(
+				ctx,
+				env,
+				tenantUUID,
+				contract.Modality(strings.ToLower(strings.TrimSpace(prof.Modality))),
+				prof.Provider,
+				prof.Model,
+				baseURL,
+				utils.FirstJSONNonEmpty(cred.Data, sensKeys...),
+			); err != nil {
+				return fmt.Errorf("连通性校验失败: %w", err)
+			}
 		}
 	} else {
 		// 没提新密钥：保留旧的 __sealed 和 base_url（如有）
@@ -159,6 +453,66 @@ func (s *AgentSettingService) SaveCredentialAndProfile(
 	})
 }
 
+// SaveCredentialOnly：用于“连接测试成功后自动保存凭据”（不写画像、不激活默认路由）
+// - 会 SealSensitive（api_key/secret/...）
+// - 若未提交新密钥，则保留旧的 __sealed / base_url
+func (s *AgentSettingService) SaveCredentialOnly(
+	ctx context.Context,
+	env string, tenantUUID *string,
+	cred *dbmodel.AIProviderCredential,
+) error {
+	if cred == nil {
+		return fmt.Errorf("credential 不能为空")
+	}
+	cred.Env, cred.TenantUUID = env, tenantUUID
+
+	// 是否提交了新密钥？
+	sensKeys := []string{"api_key", "access_token", "client_secret", "secret"}
+	hasNewSecret := false
+	for _, k := range sensKeys {
+		if cred.Data != nil {
+			if v, _ := cred.Data[k].(string); strings.TrimSpace(v) != "" {
+				hasNewSecret = true
+				break
+			}
+		}
+	}
+
+	baseURL := ""
+	if cred.Data != nil {
+		if v, _ := cred.Data["base_url"].(string); v != "" {
+			baseURL = v
+		}
+	}
+
+	// 没提新密钥：保留旧的 __sealed 和 base_url（如有）
+	if !hasNewSecret {
+		if old, err := s.credRepo.FindByScopeNameProvider(ctx, env, tenantUUID, cred.Name, cred.Provider); err == nil && old != nil {
+			if cred.Data == nil {
+				cred.Data = datatypes.JSONMap{}
+			}
+			if cred.Data["__sealed"] == nil && old.Data != nil && old.Data["__sealed"] != nil {
+				cred.Data["__sealed"] = old.Data["__sealed"]
+			}
+			if baseURL == "" && old.Data != nil {
+				if bu, _ := old.Data["base_url"].(string); strings.TrimSpace(bu) != "" {
+					cred.Data["base_url"] = bu
+				}
+			}
+		}
+	}
+
+	// 加密敏感键
+	scopeKey := s.tenantScopeKey(tenantUUID)
+	enc, err := s.tks.SealSensitive(ctx, env, scopeKey, cred.Data, sensKeys...)
+	if err != nil {
+		return err
+	}
+	cred.Data = enc
+
+	return s.credRepo.UpsertByScopeNameProvider(ctx, env, tenantUUID, cred)
+}
+
 // 从库里解密出 api_key/base_url 作为回退
 func (s *AgentSettingService) resolveConnFromStore(
 	ctx context.Context, env string, tenantUUID *string, provider string,
@@ -180,19 +534,37 @@ func (s *AgentSettingService) resolveConnFromStore(
 	}
 	// 再补 api_key（仅后端内部使用，不回前端）
 	if apiKey == "" {
+		// 兼容：历史记录可能未加密 api_key（明文存放）
+		if v, ok := cred.Data["api_key"].(string); ok && strings.TrimSpace(v) != "" {
+			apiKey = strings.TrimSpace(v)
+		} else if v, ok := cred.Data["apiKey"].(string); ok && strings.TrimSpace(v) != "" {
+			apiKey = strings.TrimSpace(v)
+		}
+
 		var sec struct {
 			APIKey string `json:"api_key"`
 			Secret string `json:"secret"`
 		}
 		if e := s.tks.UnsealSensitive(ctx, env, s.tenantScopeKey(tenantUUID), cred.Data, &sec); e == nil {
-			apiKey = sec.APIKey
+			if apiKey == "" {
+				apiKey = strings.TrimSpace(sec.APIKey)
+			}
 		}
 	}
 	return baseURL, apiKey, nil
 }
 
+// ResolveConnFromStore 用于运行时读取已保存的 credential（含解密）来补全 base_url/api_key。
+// 注意：该方法仅在后端内部使用，严禁把返回的 apiKey 透传给前端。
+func (s *AgentSettingService) ResolveConnFromStore(
+	ctx context.Context, env string, tenantUUID *string, provider string,
+	baseURLIn, apiKeyIn string,
+) (baseURL, apiKey string, err error) {
+	return s.resolveConnFromStore(ctx, env, tenantUUID, provider, baseURLIn, apiKeyIn)
+}
+
 // 只用“这次提交的表单值”直连一次（不读库、不回退、不解封）
-func (s *AgentSettingService) PingStrict(ctx context.Context, modality, provider, model, baseURL, apiKey string) error {
+func (s *AgentSettingService) PingStrict(ctx context.Context, modality, provider, model, baseURL, apiKey, secretID, secretKey, region string) error {
 	if strings.TrimSpace(provider) == "" || strings.TrimSpace(model) == "" {
 		return fmt.Errorf("provider/model 不能为空")
 	}
@@ -202,6 +574,12 @@ func (s *AgentSettingService) PingStrict(ctx context.Context, modality, provider
 	if rule.RequireAPIKey && strings.TrimSpace(apiKey) == "" {
 		return fmt.Errorf("%s/%s 需要 apiKey", provider, model)
 	}
+	if rule.RequireSecretID && strings.TrimSpace(secretID) == "" {
+		return fmt.Errorf("%s/%s 需要 secretId", provider, model)
+	}
+	if rule.RequireSecretKey && strings.TrimSpace(secretKey) == "" {
+		return fmt.Errorf("%s/%s 需要 secretKey", provider, model)
+	}
 	if strings.TrimSpace(baseURL) == "" {
 		if rule.DefaultBaseURL != "" {
 			baseURL = rule.DefaultBaseURL
@@ -209,11 +587,16 @@ func (s *AgentSettingService) PingStrict(ctx context.Context, modality, provider
 			return fmt.Errorf("%s/%s 需要 baseURL", provider, model)
 		}
 	}
+	if err := validateEndpoint(baseURL); err != nil {
+		return err
+	}
 
 	mc := agentcfg.ModelConfig{
 		Provider: provider, Endpoint: baseURL, APIKey: apiKey,
+		SecretID: secretID, SecretKey: secretKey, Region: region,
 		Model: model, SystemPrompt: "You are a health check probe.",
 		Temperature: 0, MaxTokens: 8, AccessToken: apiKey,
+		Extra: s.buildModelExtras(contract.Modality(strings.ToLower(strings.TrimSpace(modality))), provider, model),
 	}
 	cli, err := agentllm.NewClient(provider)
 	if err != nil {
@@ -222,6 +605,18 @@ func (s *AgentSettingService) PingStrict(ctx context.Context, modality, provider
 	c2, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 	_, err = cli.Invoke(c2, &mc, "ping")
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	// 常见：请求到了 HTML 页面（如 404/反爬/网关错误页），导致 JSON 解析报 '<'
+	if strings.Contains(msg, "invalid character '<' looking for beginning of value") {
+		return fmt.Errorf("上游返回非 JSON（疑似 HTML 错误页）；请检查 base_url 是否正确，以及是否被网关/反爬拦截：%w", err)
+	}
+	if strings.EqualFold(strings.TrimSpace(provider), "openrouter") &&
+		strings.Contains(msg, "is not a valid model ID") {
+		return fmt.Errorf("OpenRouter 模型 ID 无效（可能已更名或你账号无权限）：%s；建议在“模型”下拉刷新后重选，或到 OpenRouter 控制台确认可用模型 ID：%w", model, err)
+	}
 	return err
 }
 
@@ -230,7 +625,7 @@ func (s *AgentSettingService) PingStrict(ctx context.Context, modality, provider
 // 否则从库里读取已保存配置（含密钥解封）后再 ping。
 func (s *AgentSettingService) TestConnectionPreferInput(
 	ctx context.Context, env string, tenantUUID *string,
-	modality, provider, model, baseURL, apiKey string,
+	modality, provider, model, baseURL, apiKey, secretID, secretKey, region, authMode string,
 ) error {
 
 	mod := strings.ToLower(strings.TrimSpace(modality))
@@ -238,12 +633,20 @@ func (s *AgentSettingService) TestConnectionPreferInput(
 
 	switch contract.Modality(mod) {
 	case contract.ModLLM:
+		if strings.EqualFold(strings.TrimSpace(prov), "hunyuan") {
+			return s.PingHunyuan(ctx, env, tenantUUID, authMode, model, baseURL, apiKey, secretID, secretKey, region)
+		}
+
+		// 其他 provider：要求具备可用 driver
+		if _, err := agentllm.NewClient(prov); err != nil {
+			return fmt.Errorf("Provider %s 暂未实现 LLM 直连驱动，无法测试连接", prov)
+		}
 		req := catalog.AuthReqFromCatalog(prov)
 		bu, ak, err := s.prepareAuthInputs(ctx, env, tenantUUID, prov, baseURL, apiKey, req.NeedBaseURL, req.DefaultBaseURL, req.NeedKey)
 		if err != nil {
 			return err
 		}
-		return s.PingStrict(ctx, mod, prov, model, bu, ak)
+		return s.PingStrict(ctx, mod, prov, model, bu, ak, "", "", "")
 
 	default:
 		return s.PingGeneric(ctx, env, tenantUUID, contract.Modality(mod), provider, model, baseURL, apiKey)
@@ -307,11 +710,16 @@ func (s *AgentSettingService) RotateTenantCredentials(
 
 // 修改 PingLLM：多两个参数 env/tenantUUID，并支持回退解密
 func (s *AgentSettingService) PingLLM(ctx context.Context, env string, tenantUUID *string,
-	provider, model, baseURL, apiKey string,
+	provider, model, baseURL, apiKey, secretID, secretKey, region, authMode string,
 ) error {
 	if err := ensureModelExists(string(contract.ModLLM), provider, model); err != nil {
 		return err
 	}
+	p := strings.TrimSpace(strings.ToLower(provider))
+	if p == "hunyuan" {
+		return s.PingHunyuan(ctx, env, tenantUUID, authMode, model, baseURL, apiKey, secretID, secretKey, region)
+	}
+
 	req := catalog.AuthReqFromCatalog(provider)
 	var err error
 	baseURL, apiKey, err = s.prepareAuthInputs(ctx, env, tenantUUID, provider, baseURL, apiKey, req.NeedBaseURL, req.DefaultBaseURL, req.NeedKey)
@@ -362,18 +770,73 @@ func (s *AgentSettingService) PingGeneric(
 // 修改 QuickCallLLM：同样带 env/tenantUUID + 回退解密
 func (s *AgentSettingService) QuickCallLLM(
 	ctx context.Context, env string, tenantUUID *string,
-	provider, model, baseURL, apiKey string,
+	provider, model, baseURL, apiKey, secretID, secretKey, region, authMode string,
 	temperature float64, maxTokens int,
 	prompt string,
 ) (string, error) {
 	if strings.TrimSpace(prompt) == "" {
 		prompt = "Say hello in one short sentence."
 	}
-	// 回退解密
+	p := strings.TrimSpace(strings.ToLower(provider))
+	if p == "hunyuan" {
+		mode := authMode
+		if strings.TrimSpace(mode) == "" {
+			mode = "openai"
+		}
+		if strings.EqualFold(strings.TrimSpace(mode), "tc3") {
+			bu, sid, sk, rg, err := s.prepareHunyuanTC3Inputs(ctx, env, tenantUUID, baseURL, secretID, secretKey, region)
+			if err != nil {
+				return "", err
+			}
+			mc := agentcfg.ModelConfig{
+				Provider:     "hunyuan",
+				Endpoint:     bu,
+				SecretID:     sid,
+				SecretKey:    sk,
+				Region:       rg,
+				Model:        model,
+				SystemPrompt: "You are a helpful assistant.",
+				Temperature:  temperature,
+				MaxTokens:    utils.MaxInt(maxTokens, 64),
+				Extra:        s.buildModelExtras(contract.ModLLM, "hunyuan", model),
+			}
+			cli, err := agentllm.NewClient("hunyuan")
+			if err != nil {
+				return "", err
+			}
+			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			return cli.Invoke(ctx, &mc, prompt)
+		}
+		// OpenAI SDK 兼容：走 openai client
+		bu, ak, err := s.prepareHunyuanOpenAIInputs(ctx, env, tenantUUID, baseURL, apiKey)
+		if err != nil {
+			return "", err
+		}
+		mc := agentcfg.ModelConfig{
+			Provider:     "openai",
+			Endpoint:     bu,
+			APIKey:       ak,
+			Model:        model,
+			SystemPrompt: "You are a helpful assistant.",
+			Temperature:  temperature,
+			MaxTokens:    utils.MaxInt(maxTokens, 64),
+			AccessToken:  ak,
+			Extra:        s.buildModelExtras(contract.ModLLM, "hunyuan", model),
+		}
+		cli, err := agentllm.NewClient("openai")
+		if err != nil {
+			return "", err
+		}
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		return cli.Invoke(ctx, &mc, prompt)
+	}
+
+	// 回退解密（OpenAI-compatible 等）
 	var err error
 	baseURL, apiKey, err = s.resolveConnFromStore(ctx, env, tenantUUID, provider, baseURL, apiKey)
-	if err != nil { /* 忽略错误，尽量继续 */
-	}
+	if err != nil { /* 忽略错误，尽量继续 */ }
 
 	mc := agentcfg.ModelConfig{
 		Provider:     provider,
@@ -443,6 +906,246 @@ func (s *AgentSettingService) prepareAuthInputs(
 		return bu, ak, fmt.Errorf("缺少 API Key（%s 要求 api_key）", provider)
 	}
 	return bu, ak, nil
+}
+
+func (s *AgentSettingService) resolveHunyuanFromStore(
+	ctx context.Context, env string, tenantUUID *string,
+) (baseURL string, secretID string, secretKey string, region string, err error) {
+	name := utils.Slug(env + "-hunyuan")
+	cred, err := s.credRepo.FindByScopeNameProvider(ctx, env, tenantUUID, name, "hunyuan")
+	if err != nil {
+		return "", "", "", "", err
+	}
+	if v, ok := cred.Data["base_url"].(string); ok {
+		baseURL = strings.TrimSpace(v)
+	}
+	if v, ok := cred.Data["region"].(string); ok {
+		region = strings.TrimSpace(v)
+	}
+
+	// 兼容：历史记录可能未加密 secret_id/secret_key（明文存放）
+	if v, ok := cred.Data["secret_id"].(string); ok && strings.TrimSpace(v) != "" {
+		secretID = strings.TrimSpace(v)
+	} else if v, ok := cred.Data["secretId"].(string); ok && strings.TrimSpace(v) != "" {
+		secretID = strings.TrimSpace(v)
+	}
+	if v, ok := cred.Data["secret_key"].(string); ok && strings.TrimSpace(v) != "" {
+		secretKey = strings.TrimSpace(v)
+	} else if v, ok := cred.Data["secretKey"].(string); ok && strings.TrimSpace(v) != "" {
+		secretKey = strings.TrimSpace(v)
+	}
+
+	var sec struct {
+		SecretID  string `json:"secret_id"`
+		SecretKey string `json:"secret_key"`
+	}
+	if e := s.tks.UnsealSensitive(ctx, env, s.tenantScopeKey(tenantUUID), cred.Data, &sec); e == nil {
+		if secretID == "" {
+			secretID = strings.TrimSpace(sec.SecretID)
+		}
+		if secretKey == "" {
+			secretKey = strings.TrimSpace(sec.SecretKey)
+		}
+	}
+	return baseURL, secretID, secretKey, region, nil
+}
+
+func (s *AgentSettingService) hunyuanModeDefaults(mode string) (defaultBaseURL string, defaultRegion string) {
+	reg := catalog.GetGlobalAIRegister()
+	m, ok := reg.Manifest("hunyuan")
+	if !ok || m == nil {
+		return "", ""
+	}
+	target := strings.ToLower(strings.TrimSpace(mode))
+	for _, md := range m.Auth.Modes {
+		if strings.ToLower(strings.TrimSpace(md.ID)) == target {
+			if md.Defaults != nil {
+				return strings.TrimSpace(md.Defaults["base_url"]), strings.TrimSpace(md.Defaults["region"])
+			}
+			return "", ""
+		}
+	}
+	return "", ""
+}
+
+func (s *AgentSettingService) prepareHunyuanTC3Inputs(
+	ctx context.Context, env string, tenantUUID *string,
+	baseURLIn string, secretIDIn string, secretKeyIn string, regionIn string,
+) (baseURL string, secretID string, secretKey string, region string, err error) {
+	baseURL = strings.TrimSpace(baseURLIn)
+	secretID = strings.TrimSpace(secretIDIn)
+	secretKey = strings.TrimSpace(secretKeyIn)
+	region = strings.TrimSpace(regionIn)
+
+	defBase, defRegion := s.hunyuanModeDefaults("tc3")
+	// 兼容：用户在 UI 从 OpenAI 模式切到 tc3 时，可能仍保留 openai 的 base_url（带 /v1 或 hunyuan.cloud.tencent.com）。
+	// tc3 模式必须使用腾讯云 API endpoint（hunyuan.tencentcloudapi.com 风格），否则会出现 404/缺公共参数等问题。
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = strings.TrimSpace(defBase)
+	} else {
+		buIn := strings.TrimSpace(baseURL)
+		if u, e := url.Parse(buIn); e == nil {
+			host := strings.ToLower(strings.TrimSpace(u.Host))
+			// openai 兼容域名 → 强制切回 tc3 默认 endpoint
+			if strings.Contains(host, "hunyuan.cloud.tencent.com") {
+				baseURL = strings.TrimSpace(defBase)
+			} else if u.Path != "" && u.Path != "/" {
+				// tc3 endpoint 不需要 path，避免把 /v1 之类带进去
+				baseURL = strings.TrimRight(fmt.Sprintf("%s://%s", u.Scheme, u.Host), "/")
+			}
+		}
+	}
+
+	// fallback from store
+	if baseURL == "" || secretID == "" || secretKey == "" || region == "" {
+		if bu, sid, sk, rg, e := s.resolveHunyuanFromStore(ctx, env, tenantUUID); e == nil {
+			if baseURL == "" {
+				baseURL = strings.TrimSpace(bu)
+			}
+			if secretID == "" {
+				secretID = strings.TrimSpace(sid)
+			}
+			if secretKey == "" {
+				secretKey = strings.TrimSpace(sk)
+			}
+			if region == "" {
+				region = strings.TrimSpace(rg)
+			}
+		}
+	}
+
+	// apply defaults & validate
+	if baseURL == "" {
+		baseURL = strings.TrimSpace(defBase)
+	}
+	if baseURL == "" {
+		return "", "", "", "", fmt.Errorf("缺少 BaseURL（hunyuan 要求 base_url）")
+	}
+	if err := validateEndpoint(baseURL); err != nil {
+		return "", "", "", "", err
+	}
+	if secretID == "" {
+		return "", "", "", "", fmt.Errorf("缺少 SecretID（hunyuan 要求 secret_id）")
+	}
+	if secretKey == "" {
+		return "", "", "", "", fmt.Errorf("缺少 SecretKey（hunyuan 要求 secret_key）")
+	}
+	if region == "" {
+		region = defRegion
+	}
+	if region == "" {
+		region = "ap-guangzhou"
+	}
+	return baseURL, secretID, secretKey, region, nil
+}
+
+func (s *AgentSettingService) prepareHunyuanOpenAIInputs(
+	ctx context.Context,
+	env string,
+	tenantUUID *string,
+	baseURLIn string,
+	apiKeyIn string,
+) (baseURL string, apiKey string, err error) {
+	defBase, _ := s.hunyuanModeDefaults("openai")
+	// OpenAI SDK 兼容：要求 api_key + base_url
+	// 兼容：用户可能误把 tc3 endpoint（*.tencentcloudapi.com）填进来；此时强制回退到 openai 默认 base_url
+	buIn := strings.TrimSpace(baseURLIn)
+	// 关键兜底：如果用户不填 base_url，必须使用 OpenAI 模式默认值；
+	// 不能从已保存的 tc3 凭据里回填（否则会打到 hunyuan.tencentcloudapi.com 并要求 X-TC-Version）。
+	if buIn == "" {
+		buIn = strings.TrimSpace(defBase)
+	}
+	if buIn != "" {
+		if u, e := url.Parse(buIn); e == nil {
+			host := strings.ToLower(u.Host)
+			if strings.Contains(host, "tencentcloudapi.com") {
+				buIn = strings.TrimSpace(defBase)
+			} else if u.Path == "" || u.Path == "/" {
+				// 常见：只填 host，忘了 /v1
+				buIn = strings.TrimRight(buIn, "/") + "/v1"
+			}
+		} else {
+			// 非法 URL：让后续 validateEndpoint 报错更明确
+		}
+	}
+
+	bu, ak, err := s.prepareAuthInputs(ctx, env, tenantUUID, "hunyuan", buIn, apiKeyIn, true, defBase, true)
+	if err != nil && strings.Contains(err.Error(), "缺少 BaseURL") {
+		return "", "", fmt.Errorf("缺少 BaseURL（混元 OpenAI SDK/API Key 模式需要 base_url；请到腾讯云大模型 API 控制台的“OpenAI SDK 方式接入”复制 Base URL）")
+	}
+	return bu, ak, err
+}
+
+func (s *AgentSettingService) PingHunyuan(
+	ctx context.Context,
+	env string,
+	tenantUUID *string,
+	authMode string,
+	model string,
+	baseURL string,
+	apiKey string,
+	secretID string,
+	secretKey string,
+	region string,
+) error {
+	mode := strings.ToLower(strings.TrimSpace(authMode))
+	if mode == "" {
+		mode = "openai" // 默认优先 API Key（OpenAI SDK 兼容）
+	}
+	switch mode {
+	case "tc3":
+		bu, sid, sk, rg, err := s.prepareHunyuanTC3Inputs(ctx, env, tenantUUID, baseURL, secretID, secretKey, region)
+		if err != nil {
+			return err
+		}
+		mc := agentcfg.ModelConfig{
+			Provider:     "hunyuan",
+			Endpoint:     bu,
+			SecretID:     sid,
+			SecretKey:    sk,
+			Region:       rg,
+			Model:        model,
+			SystemPrompt: "You are a health check probe.",
+			Temperature:  0,
+			MaxTokens:    8,
+			Extra:        s.buildModelExtras(contract.ModLLM, "hunyuan", model),
+		}
+		cli, err := agentllm.NewClient("hunyuan")
+		if err != nil {
+			return err
+		}
+		c2, cancel := context.WithTimeout(ctx, 20*time.Second)
+		defer cancel()
+		_, err = cli.Invoke(c2, &mc, "ping")
+		return err
+	default:
+		bu, ak, err := s.prepareHunyuanOpenAIInputs(ctx, env, tenantUUID, baseURL, apiKey)
+		if err != nil {
+			return err
+		}
+		if err := validateEndpoint(bu); err != nil {
+			return err
+		}
+		mc := agentcfg.ModelConfig{
+			Provider:     "openai",
+			Endpoint:     bu,
+			APIKey:       ak,
+			Model:        model,
+			SystemPrompt: "You are a health check probe.",
+			Temperature:  0,
+			MaxTokens:    8,
+			AccessToken:  ak,
+			Extra:        s.buildModelExtras(contract.ModLLM, "hunyuan", model),
+		}
+		cli, err := agentllm.NewClient("openai")
+		if err != nil {
+			return err
+		}
+		c2, cancel := context.WithTimeout(ctx, 20*time.Second)
+		defer cancel()
+		_, err = cli.Invoke(c2, &mc, "ping")
+		return err
+	}
 }
 
 func validateEndpoint(raw string) error {
@@ -550,7 +1253,30 @@ type aiModelItem struct {
 
 // 这两个函数直接调用你现有的 catalog，全局注册器：catalog.GetGlobalAIRegister()
 func catalogGetProviders(mod string) []aiProviderItem {
-	items := catalog.GetGlobalAIRegister().Providers(mod)
+	m := strings.TrimSpace(strings.ToLower(mod))
+	reg := catalog.GetGlobalAIRegister()
+
+	// ✅ 对齐：图像/视频两套 Provider 列表保持一致：image ∪ video
+	var items []catalog.ProviderItem
+	if m == "video" || m == "image" {
+		seen := map[string]struct{}{}
+		add := func(list []catalog.ProviderItem) {
+			for _, it := range list {
+				if it.ID == "" {
+					continue
+				}
+				if _, ok := seen[it.ID]; ok {
+					continue
+				}
+				seen[it.ID] = struct{}{}
+				items = append(items, it)
+			}
+		}
+		add(reg.Providers("image"))
+		add(reg.Providers("video"))
+	} else {
+		items = reg.Providers(m)
+	}
 	out := make([]aiProviderItem, 0, len(items))
 	for _, it := range items {
 		out = append(out, aiProviderItem{ID: it.ID, Name: it.Name})
@@ -558,9 +1284,25 @@ func catalogGetProviders(mod string) []aiProviderItem {
 	return out
 }
 func catalogGetModels(mod, prov string) ([]aiModelItem, error) {
-	ms, err := catalog.GetGlobalAIRegister().Models(mod, prov)
+	m := strings.TrimSpace(strings.ToLower(mod))
+	reg := catalog.GetGlobalAIRegister()
+
+	// ✅ 对齐：图像/视频如果该模态没模型，则回退到另一模态（避免下拉为空）
+	ms, err := reg.Models(m, prov)
 	if err != nil {
 		return nil, err
+	}
+	if len(ms) == 0 {
+		if m == "video" {
+			if fallback, e := reg.Models("image", prov); e == nil && len(fallback) > 0 {
+				ms = fallback
+			}
+		}
+		if m == "image" {
+			if fallback, e := reg.Models("video", prov); e == nil && len(fallback) > 0 {
+				ms = fallback
+			}
+		}
 	}
 	out := make([]aiModelItem, 0, len(ms))
 	for _, m := range ms {
@@ -595,7 +1337,91 @@ func (s *AgentSettingService) GetActiveProfile(
 	// 没设置默认时可选一个兜底（例如最近更新的）
 	list, err := s.profRepo.ListByScope(ctx, env, tenantUUID, modality)
 	if err != nil || len(list) == 0 {
-		return nil, err
+		// 最后兜底：读取 config.yaml 的 ai.defaults（仅作为“系统默认值”，不代表已完成凭据配置）
+		cfg := agentconf.GetGlobalAIConfig()
+		if cfg == nil {
+			return nil, err
+		}
+		mod := strings.TrimSpace(strings.ToLower(modality))
+		switch mod {
+		case "llm":
+			p := strings.TrimSpace(cfg.Defaults.LLM.Provider)
+			m := strings.TrimSpace(cfg.Defaults.LLM.Model)
+			if p == "" || m == "" {
+				return nil, err
+			}
+			return &dbmodel.AIModelProfile{
+				Modality: "llm",
+				Provider: p,
+				Model:    m,
+				Label:    "config.default.llm",
+				Defaults: datatypes.JSONMap{
+					"temperature": cfg.Defaults.LLM.Temperature,
+					"maxTokens":   cfg.Defaults.LLM.MaxTokens,
+					"topP":        cfg.Defaults.LLM.TopP,
+					"stream":      cfg.Defaults.LLM.Stream,
+				},
+				Tags: []string{"llm", "config_default"},
+			}, nil
+		case "image":
+			p := strings.TrimSpace(cfg.Defaults.Image.Provider)
+			m := strings.TrimSpace(cfg.Defaults.Image.Model)
+			if p == "" || m == "" {
+				return nil, err
+			}
+			return &dbmodel.AIModelProfile{
+				Modality: "image",
+				Provider: p,
+				Model:    m,
+				Label:    "config.default.image",
+				Defaults: datatypes.JSONMap{
+					"size":       cfg.Defaults.Image.Size,
+					"quality":    cfg.Defaults.Image.Quality,
+					"format":     cfg.Defaults.Image.Format,
+					"promptHint": cfg.Defaults.Image.PromptHint,
+				},
+				Tags: []string{"image", "config_default"},
+			}, nil
+		case "embedding":
+			p := strings.TrimSpace(cfg.Defaults.Embedding.Provider)
+			m := strings.TrimSpace(cfg.Defaults.Embedding.Model)
+			if p == "" || m == "" {
+				return nil, err
+			}
+			return &dbmodel.AIModelProfile{
+				Modality: "embedding",
+				Provider: p,
+				Model:    m,
+				Label:    "config.default.embedding",
+				Defaults: datatypes.JSONMap{
+					"dimensions": cfg.Defaults.Embedding.Dimensions,
+					"truncate":   cfg.Defaults.Embedding.Truncate,
+					"batch":      cfg.Defaults.Embedding.Batch,
+				},
+				Tags: []string{"embedding", "config_default"},
+			}, nil
+		case "video":
+			p := strings.TrimSpace(cfg.Defaults.Video.Provider)
+			m := strings.TrimSpace(cfg.Defaults.Video.Model)
+			if p == "" || m == "" {
+				return nil, err
+			}
+			return &dbmodel.AIModelProfile{
+				Modality: "video",
+				Provider: p,
+				Model:    m,
+				Label:    "config.default.video",
+				Defaults: datatypes.JSONMap{
+					"resolution":     cfg.Defaults.Video.Resolution,
+					"fps":            cfg.Defaults.Video.FPS,
+					"maxDurationSec": cfg.Defaults.Video.MaxDurationSec,
+					"promptHint":     cfg.Defaults.Video.PromptHint,
+				},
+				Tags: []string{"video", "config_default"},
+			}, nil
+		default:
+			return nil, err
+		}
 	}
 	latest := list[0]
 	for i := 1; i < len(list); i++ {
@@ -619,11 +1445,19 @@ func (s *AgentSettingService) resolveModelRule(modality, provider, model string)
 	if m, ok := reg.Manifest(provider); ok && m != nil {
 		// 1) 必填项来自 auth.fields
 		reqAPI := false
+		reqSID := false
+		reqSKey := false
 		reqBase := false
 		for _, f := range m.Auth.Fields {
 			lf := strings.ToLower(strings.TrimSpace(f))
 			if lf == "api_key" {
 				reqAPI = true
+			}
+			if lf == "secret_id" {
+				reqSID = true
+			}
+			if lf == "secret_key" {
+				reqSKey = true
 			}
 			if lf == "base_url" {
 				reqBase = true
@@ -648,7 +1482,13 @@ func (s *AgentSettingService) resolveModelRule(modality, provider, model string)
 				def = v
 			}
 		}
-		return ModelRule{RequireAPIKey: reqAPI, RequireBaseURL: reqBase, DefaultBaseURL: def}
+		return ModelRule{
+			RequireAPIKey:    reqAPI,
+			RequireSecretID:  reqSID,
+			RequireSecretKey: reqSKey,
+			RequireBaseURL:   reqBase,
+			DefaultBaseURL:   def,
+		}
 	}
 	// 兜底（避免 catalog 未配置时不可用）
 	//switch strings.ToLower(provider) {

--- a/backend/internal/service/agent/chat_config_resolver.go
+++ b/backend/internal/service/agent/chat_config_resolver.go
@@ -1,0 +1,289 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	dbmodel "github.com/ArtisanCloud/PowerX/internal/server/agent/persistence/model"
+	"github.com/ArtisanCloud/PowerX/pkg/dto"
+	"gorm.io/gorm"
+)
+
+// ChatConfigResolver 在聊天执行前把“AI settings 默认 + Agent 自身覆盖 + 本次请求临时配置”
+// 汇总成一个可直接用于执行的 dto.ChatConfig（包含 provider/model/endpoint/api_key/参数）。
+//
+// 生效顺序（低 -> 高）：
+// 1) AI settings 默认（GetActiveProfile: tenant/env）
+// 2) Agent 自身 AI 覆盖（AgentSetting: tenant/env/agent）
+// 3) 本次请求临时配置（dto.ChatConfig）
+//
+// 节点级 node.params 覆盖在执行器内部处理（优先级最高），不在这里合并。
+type ChatConfigResolver struct {
+	setting *AgentSettingService
+	agent   *AgentService
+}
+
+func NewChatConfigResolver(db *gorm.DB) *ChatConfigResolver {
+	return &ChatConfigResolver{
+		setting: NewAgentSettingService(db),
+		agent:   NewAgentService(db),
+	}
+}
+
+// ResolveForAgentChat 构造本次聊天的有效 LLM 配置。
+// 如果系统未配置 AI settings（无可用的 provider/model/credential），会返回可直接展示给用户的错误信息。
+func (r *ChatConfigResolver) ResolveForAgentChat(
+	ctx context.Context,
+	env string,
+	tenantUUID *string,
+	agentID uint64,
+	req *dto.ChatConfig,
+) (*dto.ChatConfig, error) {
+	out := &dto.ChatConfig{}
+
+	// 1) AI settings 默认（tenant/env）
+	base, err := r.buildFromActiveProfile(ctx, env, tenantUUID)
+	if err != nil {
+		return nil, err
+	}
+	mergeChatConfig(out, base)
+
+	// 2) Agent 自身覆盖（tenant/env/agent）
+	agentCfg, err := r.buildFromAgentSetting(ctx, env, tenantUUID, agentID)
+	if err != nil {
+		return nil, err
+	}
+	mergeChatConfig(out, agentCfg)
+
+	// 3) 本次请求临时覆盖
+	mergeChatConfig(out, req)
+
+	// 最终校验 & 补全 endpoint/apiKey（仅当缺失时从 credential store 回填）
+	if strings.TrimSpace(out.Provider) == "" || strings.TrimSpace(out.ModelName) == "" {
+		return nil, errors.New("未配置默认 LLM：请先在「AI Settings」选择并保存一个可用的 Provider/Model（并配置凭据）")
+	}
+	if err := r.fillConnFromStore(ctx, env, tenantUUID, out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func (r *ChatConfigResolver) buildFromActiveProfile(
+	ctx context.Context,
+	env string,
+	tenantUUID *string,
+) (*dto.ChatConfig, error) {
+	prof, err := r.setting.GetActiveProfile(ctx, env, tenantUUID, "llm")
+	if err != nil || prof == nil {
+		return &dto.ChatConfig{}, nil
+	}
+
+	out := &dto.ChatConfig{
+		Provider:  strings.TrimSpace(prof.Provider),
+		ModelName: strings.TrimSpace(prof.Model),
+	}
+	applyLLMDefaultsFromProfile(out, prof)
+
+	// profile 本身不含凭据，执行时需要补 base_url/api_key
+	if strings.TrimSpace(out.Provider) != "" {
+		if err := r.fillConnFromStore(ctx, env, tenantUUID, out); err != nil {
+			// 对“仅有 config.yaml 默认但没配凭据”的场景：给清晰引导
+			return nil, errors.New("AI Settings 未配置或凭据不可用：请先在「AI Settings」保存该 Provider 的连接信息（base_url/api_key），再开始对话")
+		}
+	}
+	return out, nil
+}
+
+func (r *ChatConfigResolver) buildFromAgentSetting(
+	ctx context.Context,
+	env string,
+	tenantUUID *string,
+	agentID uint64,
+) (*dto.ChatConfig, error) {
+	if agentID == 0 {
+		return &dto.ChatConfig{}, nil
+	}
+	setting, err := r.agent.GetAgentAISetting(ctx, env, tenantUUID, agentID)
+	if err != nil || setting == nil {
+		return &dto.ChatConfig{}, nil
+	}
+	return chatConfigFromAgentSetting(setting), nil
+}
+
+func (r *ChatConfigResolver) fillConnFromStore(
+	ctx context.Context,
+	env string,
+	tenantUUID *string,
+	c *dto.ChatConfig,
+) error {
+	if c == nil {
+		return nil
+	}
+	p := strings.TrimSpace(c.Provider)
+	if p == "" {
+		return nil
+	}
+	baseURL, apiKey, err := r.setting.ResolveConnFromStore(ctx, env, tenantUUID, p, c.Endpoint, c.APIKey)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(c.Endpoint) == "" {
+		c.Endpoint = baseURL
+	}
+	if strings.TrimSpace(c.APIKey) == "" {
+		c.APIKey = apiKey
+	}
+	return nil
+}
+
+func mergeChatConfig(dst *dto.ChatConfig, src *dto.ChatConfig) {
+	if dst == nil || src == nil {
+		return
+	}
+	if strings.TrimSpace(src.Provider) != "" {
+		dst.Provider = strings.TrimSpace(src.Provider)
+	}
+	if strings.TrimSpace(src.ModelName) != "" {
+		dst.ModelName = strings.TrimSpace(src.ModelName)
+	}
+	if strings.TrimSpace(src.Endpoint) != "" {
+		dst.Endpoint = strings.TrimSpace(src.Endpoint)
+	}
+	if strings.TrimSpace(src.APIKey) != "" {
+		dst.APIKey = strings.TrimSpace(src.APIKey)
+	}
+	if strings.TrimSpace(src.SystemPrompt) != "" {
+		dst.SystemPrompt = strings.TrimSpace(src.SystemPrompt)
+	}
+	if src.Temperature > 0 {
+		dst.Temperature = src.Temperature
+	}
+	if src.MaxTokens > 0 {
+		dst.MaxTokens = src.MaxTokens
+	}
+	if src.EnableStream {
+		dst.EnableStream = true
+	}
+}
+
+func applyLLMDefaultsFromProfile(out *dto.ChatConfig, prof *dbmodel.AIModelProfile) {
+	if out == nil || prof == nil || prof.Defaults == nil {
+		return
+	}
+	if v, ok := prof.Defaults["temperature"]; ok {
+		if f, ok2 := asFloat64(v); ok2 && f > 0 {
+			out.Temperature = f
+		}
+	}
+	if v, ok := prof.Defaults["maxTokens"]; ok {
+		if i, ok2 := asInt(v); ok2 && i > 0 {
+			out.MaxTokens = i
+		}
+	}
+	if v, ok := prof.Defaults["max_tokens"]; ok {
+		if i, ok2 := asInt(v); ok2 && i > 0 {
+			out.MaxTokens = i
+		}
+	}
+	if v, ok := prof.Defaults["topP"]; ok {
+		// dto.ChatConfig 没有 top_p 字段；这里暂不透传，避免“看似配置了但不生效”的误导
+		_ = v
+	}
+	if v, ok := prof.Defaults["stream"]; ok {
+		if b, ok2 := v.(bool); ok2 && b {
+			out.EnableStream = true
+		}
+	}
+}
+
+func chatConfigFromAgentSetting(setting *dbmodel.AgentSetting) *dto.ChatConfig {
+	if setting == nil {
+		return &dto.ChatConfig{}
+	}
+	hasFlags := len(setting.OverrideFlags) > 0
+	allow := func(key string) bool {
+		if !hasFlags {
+			return true
+		}
+		if v, ok := setting.OverrideFlags[key]; ok {
+			if b, ok2 := v.(bool); ok2 {
+				return b
+			}
+		}
+		return false
+	}
+
+	out := &dto.ChatConfig{}
+	if allow("provider") && strings.TrimSpace(setting.Provider) != "" {
+		out.Provider = strings.TrimSpace(setting.Provider)
+	}
+	if allow("model") && strings.TrimSpace(setting.Model) != "" {
+		out.ModelName = strings.TrimSpace(setting.Model)
+	}
+
+	// params（目前前端仅写 provider/model；这里先做通用支持）
+	if setting.Params != nil {
+		if allow("temperature") {
+			if v, ok := setting.Params["temperature"]; ok {
+				if f, ok2 := asFloat64(v); ok2 && f > 0 {
+					out.Temperature = f
+				}
+			}
+		}
+		if allow("max_tokens") || allow("maxTokens") {
+			if v, ok := setting.Params["max_tokens"]; ok {
+				if i, ok2 := asInt(v); ok2 && i > 0 {
+					out.MaxTokens = i
+				}
+			}
+			if v, ok := setting.Params["maxTokens"]; ok {
+				if i, ok2 := asInt(v); ok2 && i > 0 {
+					out.MaxTokens = i
+				}
+			}
+		}
+		if allow("system_prompt") || allow("systemPrompt") {
+			if v, ok := setting.Params["system_prompt"]; ok {
+				if s, ok2 := v.(string); ok2 && strings.TrimSpace(s) != "" {
+					out.SystemPrompt = strings.TrimSpace(s)
+				}
+			}
+			if v, ok := setting.Params["systemPrompt"]; ok {
+				if s, ok2 := v.(string); ok2 && strings.TrimSpace(s) != "" {
+					out.SystemPrompt = strings.TrimSpace(s)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func asFloat64(v any) (float64, bool) {
+	switch vv := v.(type) {
+	case float64:
+		return vv, true
+	case float32:
+		return float64(vv), true
+	case int:
+		return float64(vv), true
+	case int64:
+		return float64(vv), true
+	}
+	return 0, false
+}
+
+func asInt(v any) (int, bool) {
+	switch vv := v.(type) {
+	case int:
+		return vv, true
+	case int64:
+		return int(vv), true
+	case float64:
+		return int(vv), true
+	case float32:
+		return int(vv), true
+	}
+	return 0, false
+}

--- a/backend/internal/service/agent/chat_history_service.go
+++ b/backend/internal/service/agent/chat_history_service.go
@@ -154,10 +154,24 @@ func (s *ChatHistoryService) ArchiveSession(
 func (s *ChatHistoryService) DeleteSession(
 	ctx context.Context, env string, tenantUUID *string, id uint64,
 ) error {
-	if err := s.msg.DeleteBySession(ctx, env, tenantUUID, id); err != nil {
+	// 先软删会话，保证前端“删除”动作能快速返回（从列表中消失）。
+	// 会话内消息清理由后台异步 best-effort 完成，避免消息量大时阻塞 HTTP 请求直至超时。
+	if err := s.sess.DeleteSoft(ctx, id); err != nil {
 		return err
 	}
-	return s.sess.DeleteSoft(ctx, id)
+
+	go func() {
+		var tenantCopy *string
+		if tenantUUID != nil {
+			v := *tenantUUID
+			tenantCopy = &v
+		}
+		ctx2, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		_ = s.msg.DeleteBySession(ctx2, env, tenantCopy, id)
+	}()
+
+	return nil
 }
 
 // ListMessages：会话内分页拉取消息（支持 afterID 游标）
@@ -202,6 +216,57 @@ func (s *ChatHistoryService) AppendMessage(
 	// 续期 latest/expired_at
 	_ = s.sess.TouchLatest(ctx, env, tenantUUID, sessionID, time.Now().UTC())
 	return m, nil
+}
+
+// FindMessageByID：读取单条消息（带 scope），用于“从某条 user 消息重新生成”等场景。
+func (s *ChatHistoryService) FindMessageByID(
+	ctx context.Context, env string, tenantUUID *string, id uint64,
+) (*dbmodel.AgentChatMessage, error) {
+	var out dbmodel.AgentChatMessage
+	err := s.db.WithContext(ctx).
+		Model(&dbmodel.AgentChatMessage{}).
+		Scopes(dbmodel.WithScope(env, tenantUUID)).
+		Where("id = ?", id).
+		First(&out).Error
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// TruncateMessagesAfter：删除会话内 id > afterID 的消息，用于“从此问题重新生成”（裁剪后续对话）。
+func (s *ChatHistoryService) TruncateMessagesAfter(
+	ctx context.Context, env string, tenantUUID *string, sessionID uint64, afterID uint64,
+) (int64, error) {
+	affected, err := s.msg.DeleteAfterID(ctx, env, tenantUUID, sessionID, afterID)
+	if err != nil {
+		return 0, err
+	}
+	_ = s.sess.TouchLatest(ctx, env, tenantUUID, sessionID, time.Now().UTC())
+	return affected, nil
+}
+
+// UpdateMessageContent：更新单条消息内容（带 scope），用于“编辑问题后重新生成”等场景。
+func (s *ChatHistoryService) UpdateMessageContent(
+	ctx context.Context, env string, tenantUUID *string, id uint64, content string,
+) error {
+	content = strings.TrimSpace(content)
+	ct := "text/plain"
+	if content == "" {
+		ct = "text/plain"
+	}
+	return s.db.WithContext(ctx).
+		Model(&dbmodel.AgentChatMessage{}).
+		Scopes(dbmodel.WithScope(env, tenantUUID)).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"content":     content,
+			"size_bytes":  len([]byte(content)),
+			"updated_at":  time.Now().UTC(),
+			"is_error":    false,
+			"tokens":      0,
+			"content_type": ct,
+		}).Error
 }
 
 // SummarizeIfNeeded：当消息/体量超过阈值或会话过期时，生成滚动摘要并续期

--- a/backend/internal/transport/grpc/agent/setting_handler.go
+++ b/backend/internal/transport/grpc/agent/setting_handler.go
@@ -93,7 +93,7 @@ func (s *SettingAIServiceServer) SaveSettings(ctx context.Context, req *settingv
 	// 直连校验（以 LLM 为例）
 	if req.GetLlm() != nil {
 		base := req.GetLlm().GetBase()
-		if err := s.svc.PingLLM(ctx, env, &tenantRef, base.GetProvider(), base.GetModel(), base.GetBaseUrl(), base.GetApiKey()); err != nil {
+		if err := s.svc.PingLLM(ctx, env, &tenantRef, base.GetProvider(), base.GetModel(), base.GetBaseUrl(), base.GetApiKey(), "", "", base.GetRegion(), ""); err != nil {
 			return &settingv1.SaveSettingsResponse{
 				Meta: badMeta(ctx, 400, err.Error(), req.GetCtx().GetRequestId()),
 				Data: &settingv1.SaveSettingsData{Ok: false},
@@ -131,7 +131,7 @@ func (s *SettingAIServiceServer) TestConnection(ctx context.Context, req *settin
 	}
 	tenantRef := tenantUUID
 	provider, model, baseURL, apiKey := pickProviderModelConn(req.GetModality(), req)
-	if err := s.svc.TestConnectionPreferInput(ctx, env, &tenantRef, modalityToString(req.GetModality()), provider, model, baseURL, apiKey); err != nil {
+	if err := s.svc.TestConnectionPreferInput(ctx, env, &tenantRef, modalityToString(req.GetModality()), provider, model, baseURL, apiKey, "", "", "", ""); err != nil {
 		return &settingv1.TestConnectionResponse{
 			Meta: badMeta(ctx, 400, err.Error(), req.GetCtx().GetRequestId()),
 			Data: &settingv1.TestConnectionData{Ok: false},
@@ -163,7 +163,7 @@ func (s *SettingAIServiceServer) TestQuickCall(ctx context.Context, req *setting
 	b := req.GetLlm().GetBase()
 	out, err := s.svc.QuickCallLLM(
 		ctx, env, &tenantRef,
-		b.GetProvider(), b.GetModel(), b.GetBaseUrl(), b.GetApiKey(),
+		b.GetProvider(), b.GetModel(), b.GetBaseUrl(), b.GetApiKey(), "", "", b.GetRegion(), "",
 		req.GetLlm().GetTemperature(), int(req.GetLlm().GetMaxTokens()),
 		strings.TrimSpace(req.GetPrompt()),
 	)

--- a/backend/internal/transport/grpc/agent/stream_handler.go
+++ b/backend/internal/transport/grpc/agent/stream_handler.go
@@ -22,12 +22,14 @@ import (
 /******** server ********/
 type AgentStreamServer struct {
 	v1.UnimplementedAgentStreamServiceServer
-	his *agentSvc.ChatHistoryService
+	his         *agentSvc.ChatHistoryService
+	cfgResolver *agentSvc.ChatConfigResolver
 }
 
 func NewAgentStreamServer(deps *shared.Deps) *AgentStreamServer {
 	return &AgentStreamServer{
-		his: agentSvc.NewChatHistoryService(deps.DB),
+		his:         agentSvc.NewChatHistoryService(deps.DB),
+		cfgResolver: agentSvc.NewChatConfigResolver(deps.DB),
 	}
 }
 
@@ -107,7 +109,20 @@ func (s *AgentStreamServer) Stream(req *v1.StreamRequest, srv v1.AgentStreamServ
 	hist := newTokenHistory(s.his, ctx, env, tenantUUID, sess, agentID)
 	engineSink := eventChain(sink, hist)
 
-	cfg := &dto.ChatConfig{} // 与 HTTP 保持一致
+	cfg, cfgErr := s.cfgResolver.ResolveForAgentChat(ctx, env, tenantUUID, agentID, nil)
+	if cfgErr != nil {
+		_ = srv.Send(&v1.StreamResponse{
+			Type:      dto.EventError,
+			Timestamp: now(),
+			Payload:   &v1.StreamResponse_EvError{EvError: &v1.EventError{Message: cfgErr.Error()}},
+		})
+		_ = srv.Send(&v1.StreamResponse{
+			Type:      dto.EventEnd,
+			Timestamp: now(),
+			Payload:   &v1.StreamResponse_EvEnd{EvEnd: &v1.EventEnd{Message: "failed"}},
+		})
+		return nil
+	}
 	return runtime.NewEngine().Run(ctx, msg, cfg, strings.TrimSpace(req.GetFlowId()), engineSink)
 }
 

--- a/backend/internal/transport/http/admin/agent/chat_handler.go
+++ b/backend/internal/transport/http/admin/agent/chat_handler.go
@@ -22,12 +22,14 @@ import (
 )
 
 type AgentChatHandler struct {
-	his *agentSvc.ChatHistoryService
+	his         *agentSvc.ChatHistoryService
+	cfgResolver *agentSvc.ChatConfigResolver
 }
 
 func NewAgentChatHandler(dep *shared.Deps) *AgentChatHandler {
 	return &AgentChatHandler{
-		his: agentSvc.NewChatHistoryService(dep.DB),
+		his:         agentSvc.NewChatHistoryService(dep.DB),
+		cfgResolver: agentSvc.NewChatConfigResolver(dep.DB),
 	}
 }
 
@@ -146,7 +148,8 @@ func (h *AgentChatHandler) StreamSSE(c *gin.Context) {
 	// 2) 解析入参 & 会话（保持你现有逻辑）
 	env := c.DefaultQuery("env", "default")
 	q := strings.TrimSpace(utils.FirstNonEmpty(c.Query("q"), c.Query("message")))
-	if q == "" {
+	regenFromID, _ := utils.ParseUintID(strings.TrimSpace(c.Query("regen_from_message_id")))
+	if q == "" && regenFromID == 0 {
 		dto.ResponseError(c, 400, "缺少 q（消息内容）", nil)
 		return
 	}
@@ -175,16 +178,56 @@ func (h *AgentChatHandler) StreamSSE(c *gin.Context) {
 		}
 	}
 
-	// 写入 user 消息
-	_, _ = h.his.AppendMessage(c, env, tenantRef, sess.ID, agentID, "user", q, "text", 0, 0, false, nil)
-
 	// 3) 适配器 + Engine
 	runtime.SetSSEHeaders(c)
 	baseSink := runtime.NewSSESink(c)
 	histSink := runtime.NewHistorySink(baseSink, h.his, c, env, tenantRef, sess, agentID, true)
 
-	cfg := &dto.ChatConfig{}                             // 如需从 query/form 取开关可补
-	_ = runtime.NewEngine().Run(c, q, cfg, "", histSink) // explicitFlow 传空，交给意图/plan 选择
+	// 支持“从某条 user 消息重新生成”：裁剪后续消息并以该消息内容作为 prompt
+	if regenFromID > 0 {
+		msgRec, err := h.his.FindMessageByID(c, env, tenantRef, regenFromID)
+		if err != nil || msgRec == nil || msgRec.SessionID != sess.ID || strings.ToLower(strings.TrimSpace(msgRec.Role)) != "user" {
+			_ = histSink.Emit(dto.EventError, map[string]any{"message": "regen_from_message_id 无效或不属于该会话"})
+			_ = histSink.Emit(dto.EventEnd, map[string]any{"success": false})
+			return
+		}
+		// 允许前端传 q 作为“编辑后的问题”，并更新这条 user 消息内容
+		if strings.TrimSpace(q) != "" && strings.TrimSpace(q) != strings.TrimSpace(msgRec.Content) {
+			if err := h.his.UpdateMessageContent(c, env, tenantRef, regenFromID, q); err == nil {
+				msgRec.Content = strings.TrimSpace(q)
+			}
+		}
+		_, _ = h.his.TruncateMessagesAfter(c, env, tenantRef, sess.ID, regenFromID)
+		q = strings.TrimSpace(msgRec.Content)
+		_ = histSink.Emit(dto.EventMeta, map[string]any{
+			"session_id":              sess.ID,
+			"agent_id":                agentID,
+			"regen_from_message_id":   regenFromID,
+			"regen_from_message_role": "user",
+		})
+	} else {
+		// 正常发送：先写入 user 消息，并把 DB message_id 回传给前端用于“从此问题重新生成”
+		clientMsgID := strings.TrimSpace(c.Query("client_msg_id"))
+		userMsg, _ := h.his.AppendMessage(c, env, tenantRef, sess.ID, agentID, "user", q, "text", 0, 0, false, nil)
+		if userMsg != nil {
+			_ = histSink.Emit(dto.EventMeta, map[string]any{
+				"session_id":        sess.ID,
+				"agent_id":          agentID,
+				"user_message_id":   userMsg.ID,
+				"client_msg_id":     clientMsgID,
+				"user_message_role": "user",
+			})
+		}
+	}
+
+	cfg, cfgErr := h.cfgResolver.ResolveForAgentChat(c.Request.Context(), env, tenantRef, agentID, nil)
+	if cfgErr != nil {
+		_ = histSink.Emit(dto.EventError, map[string]any{"message": cfgErr.Error()})
+		_ = histSink.Emit(dto.EventEnd, map[string]any{"success": false})
+		return
+	}
+
+	_ = runtime.NewEngine().Run(c.Request.Context(), q, cfg, "", histSink) // explicitFlow 传空，交给意图/plan 选择
 }
 
 // ---- 核心 ----

--- a/backend/internal/transport/http/admin/agent/setting_handler.go
+++ b/backend/internal/transport/http/admin/agent/setting_handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ArtisanCloud/PowerX/internal/app/shared"
+	"github.com/ArtisanCloud/PowerX/internal/server/agent/catalog"
 	"github.com/ArtisanCloud/PowerX/internal/server/agent/contract"
 	dbmodel "github.com/ArtisanCloud/PowerX/internal/server/agent/persistence/model"
 	agentSvc "github.com/ArtisanCloud/PowerX/internal/service/agent"
@@ -46,7 +47,10 @@ type baseConn struct {
 	Name            string `form:"name"`
 	Provider        string `json:"provider" validate:"required"`
 	Model           string `json:"model"    validate:"required"`
+	AuthMode        string `json:"authMode"`
 	APIKey          string `json:"apiKey"`
+	SecretID        string `json:"secretId"`
+	SecretKey       string `json:"secretKey"`
 	BaseURL         string `json:"baseURL"`
 	Region          string `json:"region"`
 	Organization    string `json:"organization"`
@@ -83,6 +87,12 @@ type modVideo struct {
 	PromptHint     string `json:"promptHint"`
 }
 
+type modModel3D struct {
+	baseConn
+	OutputFormat string `json:"outputFormat"`
+	PromptHint   string `json:"promptHint"`
+}
+
 type modAudioTTS struct {
 	baseConn
 	Voice   string  `json:"voice"`
@@ -113,6 +123,7 @@ type saveSettingsReq struct {
 	Image     *modImage         `json:"image,omitempty"`
 	Embedding *modEmbed         `json:"embedding,omitempty"`
 	Video     *modVideo         `json:"video,omitempty"`
+	Model3D   *modModel3D       `json:"model3d,omitempty"`
 	AudioTTS  *modAudioTTS      `json:"audio_tts,omitempty"`
 	AudioASR  *modAudioASR      `json:"audio_asr,omitempty"`
 	Rerank    *modRerank        `json:"rerank,omitempty"`
@@ -125,6 +136,7 @@ type testReq struct {
 	Image     *modImage         `json:"image,omitempty"`
 	Embedding *modEmbed         `json:"embedding,omitempty"`
 	Video     *modVideo         `json:"video,omitempty"`
+	Model3D   *modModel3D       `json:"model3d,omitempty"`
 	AudioTTS  *modAudioTTS      `json:"audio_tts,omitempty"`
 	AudioASR  *modAudioASR      `json:"audio_asr,omitempty"`
 	Rerank    *modRerank        `json:"rerank,omitempty"`
@@ -138,6 +150,7 @@ type testCallReq struct {
 	Image     *modImage         `json:"image,omitempty"`
 	Embedding *modEmbed         `json:"embedding,omitempty"`
 	Video     *modVideo         `json:"video,omitempty"`
+	Model3D   *modModel3D       `json:"model3d,omitempty"`
 	AudioTTS  *modAudioTTS      `json:"audio_tts,omitempty"`
 	AudioASR  *modAudioASR      `json:"audio_asr,omitempty"`
 	Rerank    *modRerank        `json:"rerank,omitempty"`
@@ -146,16 +159,183 @@ type testCallReq struct {
 // ---------- Providers / Models ----------
 
 func (h *AgentSettingHandler) listProviders(c *gin.Context) {
-	mod := c.Query("modality")
+	env := c.DefaultQuery("env", "dev")
+	mod := strings.TrimSpace(strings.ToLower(c.Query("modality")))
+	if mod == "" {
+		mod = "llm"
+	}
 	list := h.svc.Providers(mod)
-	dtoRequest.ResponseSuccess(c, gin.H{"providers": list})
+	reg := catalog.GetGlobalAIRegister()
+
+	tenantCtx, err := requireTenantContext(c)
+	if err != nil {
+		dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+	tenantRef := tenantCtx.UUIDPtr()
+	tenantUUID := tenantCtx.UUID()
+
+	// 1) 已配置：credentials 是否存在（仅按 provider 维度）
+	creds, err := h.svc.ListCredentials(c.Request.Context(), env, tenantRef)
+	if err != nil {
+		dtoRequest.ResponseError(c, http.StatusInternalServerError, "查询凭据失败", err)
+		return
+	}
+	configured := map[string]struct{}{}
+	for i := range creds {
+		p := strings.ToLower(strings.TrimSpace(creds[i].Provider))
+		if p != "" {
+			// 兼容历史 provider/别名（例如 yuanbao -> hunyuan）
+			if canon := reg.CanonicalProvider(p); canon != "" {
+				p = canon
+			}
+			configured[p] = struct{}{}
+		}
+	}
+
+	// 2) 连接测试：记录在租户设置里（env+modality 维度）
+	healthMap, _, err := h.svc.GetTenantProviderHealthMap(c.Request.Context(), tenantUUID, env, mod)
+	if err != nil {
+		dtoRequest.ResponseError(c, http.StatusInternalServerError, "查询连接测试结果失败", err)
+		return
+	}
+	// 同样把 healthMap key 规范化到 canonical provider id
+	healthNorm := map[string]agentSvc.ProviderHealthRecord{}
+	for k, v := range healthMap {
+		p := strings.ToLower(strings.TrimSpace(k))
+		if p == "" {
+			continue
+		}
+		if canon := reg.CanonicalProvider(p); canon != "" {
+			p = canon
+		}
+		// 冲突时保留第一次写入（更贴近用户原始配置）
+		if _, ok := healthNorm[p]; ok {
+			continue
+		}
+		healthNorm[p] = v
+	}
+
+	type providerView struct {
+		ID         string                         `json:"ID"`
+		Name       string                         `json:"Name"`
+		Configured bool                           `json:"configured"`
+		Health     *agentSvc.ProviderHealthRecord `json:"health,omitempty"`
+		Auth       *struct {
+			Scheme   string            `json:"scheme,omitempty"`
+			Fields   []string          `json:"fields,omitempty"`
+			Defaults map[string]string `json:"defaults,omitempty"`
+			Modes    []struct {
+				ID       string            `json:"id"`
+				Label    string            `json:"label,omitempty"`
+				Scheme   string            `json:"scheme,omitempty"`
+				Fields   []string          `json:"fields,omitempty"`
+				Defaults map[string]string `json:"defaults,omitempty"`
+			} `json:"modes,omitempty"`
+		} `json:"auth,omitempty"`
+	}
+	out := make([]providerView, 0, len(list))
+	for _, it := range list {
+		p := strings.ToLower(strings.TrimSpace(it.ID))
+		_, ok := configured[p]
+		var hr *agentSvc.ProviderHealthRecord
+		if v, hit := healthNorm[p]; hit {
+			clone := v
+			hr = &clone
+		}
+		var authView *struct {
+			Scheme   string            `json:"scheme,omitempty"`
+			Fields   []string          `json:"fields,omitempty"`
+			Defaults map[string]string `json:"defaults,omitempty"`
+			Modes    []struct {
+				ID       string            `json:"id"`
+				Label    string            `json:"label,omitempty"`
+				Scheme   string            `json:"scheme,omitempty"`
+				Fields   []string          `json:"fields,omitempty"`
+				Defaults map[string]string `json:"defaults,omitempty"`
+			} `json:"modes,omitempty"`
+		}
+		if m, ok2 := reg.Manifest(it.ID); ok2 && m != nil {
+			authView = &struct {
+				Scheme   string            `json:"scheme,omitempty"`
+				Fields   []string          `json:"fields,omitempty"`
+				Defaults map[string]string `json:"defaults,omitempty"`
+				Modes    []struct {
+					ID       string            `json:"id"`
+					Label    string            `json:"label,omitempty"`
+					Scheme   string            `json:"scheme,omitempty"`
+					Fields   []string          `json:"fields,omitempty"`
+					Defaults map[string]string `json:"defaults,omitempty"`
+				} `json:"modes,omitempty"`
+			}{
+				Scheme:   m.Auth.Scheme,
+				Fields:   m.Auth.Fields,
+				Defaults: m.Auth.Defaults,
+				Modes: func() []struct {
+					ID       string            `json:"id"`
+					Label    string            `json:"label,omitempty"`
+					Scheme   string            `json:"scheme,omitempty"`
+					Fields   []string          `json:"fields,omitempty"`
+					Defaults map[string]string `json:"defaults,omitempty"`
+				} {
+					if len(m.Auth.Modes) == 0 {
+						return nil
+					}
+					out := make([]struct {
+						ID       string            `json:"id"`
+						Label    string            `json:"label,omitempty"`
+						Scheme   string            `json:"scheme,omitempty"`
+						Fields   []string          `json:"fields,omitempty"`
+						Defaults map[string]string `json:"defaults,omitempty"`
+					}, 0, len(m.Auth.Modes))
+					for _, md := range m.Auth.Modes {
+						out = append(out, struct {
+							ID       string            `json:"id"`
+							Label    string            `json:"label,omitempty"`
+							Scheme   string            `json:"scheme,omitempty"`
+							Fields   []string          `json:"fields,omitempty"`
+							Defaults map[string]string `json:"defaults,omitempty"`
+						}{
+							ID:       md.ID,
+							Label:    md.Label,
+							Scheme:   md.Scheme,
+							Fields:   md.Fields,
+							Defaults: md.Defaults,
+						})
+					}
+					return out
+				}(),
+			}
+		}
+		out = append(out, providerView{
+			ID:         it.ID,
+			Name:       it.Name,
+			Configured: ok,
+			Health:     hr,
+			Auth:       authView,
+		})
+	}
+
+	dtoRequest.ResponseSuccess(c, gin.H{
+		"env":       env,
+		"modality":  mod,
+		"providers": out,
+	})
 	return
 }
 
 func (h *AgentSettingHandler) listModels(c *gin.Context) {
+	env := c.DefaultQuery("env", "dev")
 	mod := c.Query("modality")
 	prov := c.Query("provider")
-	models, err := h.svc.Models(mod, prov)
+
+	tenantCtx, err := requireTenantContext(c)
+	if err != nil {
+		dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+
+	models, err := h.svc.ModelsForTenant(c.Request.Context(), env, tenantCtx.UUIDPtr(), mod, prov)
 	if err != nil {
 		dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
 		return
@@ -194,7 +374,21 @@ func (h *AgentSettingHandler) saveSettings(c *gin.Context) {
 			req.LLM.Model,
 			req.LLM.BaseURL,
 			req.LLM.APIKey,
+			req.LLM.SecretID,
+			req.LLM.SecretKey,
+			req.LLM.Region,
+			req.LLM.AuthMode,
 		); err != nil {
+			// 记录最近一次测试状态（便于智能体配置页筛选/排障）
+			_ = h.svc.UpsertTenantProviderHealth(
+				c.Request.Context(),
+				tenantUUID,
+				req.Env,
+				string(req.Modality),
+				req.LLM.Provider,
+				"unhealthy",
+				err.Error(),
+			)
 			dtoRequest.ResponseError(c, http.StatusBadRequest, "连通性校验失败", err)
 			return
 		}
@@ -211,6 +405,11 @@ func (h *AgentSettingHandler) saveSettings(c *gin.Context) {
 	case contract.ModVideo:
 		if req.Video == nil || strings.TrimSpace(req.Video.Provider) == "" || strings.TrimSpace(req.Video.Model) == "" {
 			dtoRequest.ResponseError(c, http.StatusBadRequest, "video.provider/model 不能为空", nil)
+			return
+		}
+	case contract.ModModel3D:
+		if req.Model3D == nil || strings.TrimSpace(req.Model3D.Provider) == "" || strings.TrimSpace(req.Model3D.Model) == "" {
+			dtoRequest.ResponseError(c, http.StatusBadRequest, "model3d.provider/model 不能为空", nil)
 			return
 		}
 	case contract.ModAudioTTS:
@@ -241,12 +440,34 @@ func (h *AgentSettingHandler) saveSettings(c *gin.Context) {
 		TenantUUID: tenantRef,
 		Name:       credName,
 		Provider:   credProvider,
-		AuthScheme: "bearer",
+		AuthScheme: func() string {
+			scheme := "bearer"
+			if m, ok := catalog.GetGlobalAIRegister().Manifest(credProvider); ok && m != nil {
+				if s := strings.TrimSpace(m.Auth.Scheme); s != "" {
+					scheme = s
+				}
+			}
+			return scheme
+		}(),
 		Data:       credData,
 	}
 	if err := h.svc.SaveCredentialAndProfile(c.Request.Context(), req.Env, tenantRef, cred, prof, true); err != nil {
 		dtoRequest.ResponseError(c, http.StatusInternalServerError, "保存失败", err)
 		return
+	}
+	// ✅ 产品语义：当 LLM 配置保存成功，更新“租户当前 AI 环境”
+	if req.Modality == contract.ModLLM {
+		// 保存成功代表连通性校验通过：同步写入“可用 Provider”缓存
+		_ = h.svc.UpsertTenantProviderHealth(
+			c.Request.Context(),
+			tenantUUID,
+			req.Env,
+			string(req.Modality),
+			req.LLM.Provider,
+			"healthy",
+			"ok",
+		)
+		_ = h.svc.SetTenantCurrentAIEnv(c.Request.Context(), tenantUUID, req.Env)
 	}
 	dtoRequest.ResponseSuccess(c, gin.H{"ok": true, "tenant_uuid": tenantUUID})
 }
@@ -267,6 +488,37 @@ func (h *AgentSettingHandler) testConnection(c *gin.Context) {
 	tenantRef := tenantCtx.UUIDPtr()
 	tenantUUID := tenantCtx.UUID()
 
+	saveVerifiedCredential := func(provider, apiKey, secretID, secretKey, baseURL, region, organization, azureDeployment, authMode string) error {
+		p := strings.TrimSpace(provider)
+		if p == "" {
+			return nil
+		}
+		scheme := "bearer"
+		if m, ok := catalog.GetGlobalAIRegister().Manifest(p); ok && m != nil {
+			if s := strings.TrimSpace(m.Auth.Scheme); s != "" {
+				scheme = s
+			}
+		}
+		cred := &dbmodel.AIProviderCredential{
+			Env:        req.Env,
+			TenantUUID: tenantRef,
+			Name:       utils.Slug(req.Env + "-" + p),
+			Provider:   p,
+			AuthScheme: scheme,
+			Data: datatypes.JSONMap{
+				"api_key":          apiKey,
+				"secret_id":        secretID,
+				"secret_key":       secretKey,
+				"auth_mode":        authMode,
+				"base_url":         baseURL,
+				"region":           region,
+				"organization":     organization,
+				"azure_deployment": azureDeployment,
+			},
+		}
+		return h.svc.SaveCredentialOnly(c.Request.Context(), req.Env, tenantRef, cred)
+	}
+
 	switch req.Modality {
 	case contract.ModLLM:
 		if req.LLM == nil {
@@ -279,13 +531,17 @@ func (h *AgentSettingHandler) testConnection(c *gin.Context) {
 			c.Request.Context(),
 			req.Env, tenantRef,
 			string(req.Modality),
-			provider, model, req.LLM.BaseURL, req.LLM.APIKey,
+			provider, model, req.LLM.BaseURL, req.LLM.APIKey, req.LLM.SecretID, req.LLM.SecretKey, req.LLM.Region, req.LLM.AuthMode,
 		)
 		if err != nil {
+			_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), provider, "unhealthy", err.Error())
 			h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, provider, model, false, err.Error())
 			dtoRequest.ResponseError(c, http.StatusBadRequest, "连接测试失败", err)
 			return
 		}
+		// ✅ 测试通过：自动保存该 provider 的凭据（不激活默认路由）
+		_ = saveVerifiedCredential(provider, req.LLM.APIKey, req.LLM.SecretID, req.LLM.SecretKey, req.LLM.BaseURL, req.LLM.Region, req.LLM.Organization, req.LLM.AzureDeployment, req.LLM.AuthMode)
+		_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), provider, "healthy", "ok")
 		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, provider, model, true, "ok")
 		dtoRequest.ResponseSuccess(c, gin.H{"ok": true})
 	case contract.ModImage:
@@ -294,10 +550,13 @@ func (h *AgentSettingHandler) testConnection(c *gin.Context) {
 			return
 		}
 		if err := h.svc.PingGeneric(c.Request.Context(), req.Env, tenantRef, req.Modality, req.Image.Provider, req.Image.Model, req.Image.BaseURL, req.Image.APIKey); err != nil {
+			_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Image.Provider, "unhealthy", err.Error())
 			h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Image.Provider, req.Image.Model, false, err.Error())
 			dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		_ = saveVerifiedCredential(req.Image.Provider, req.Image.APIKey, "", "", req.Image.BaseURL, req.Image.Region, req.Image.Organization, req.Image.AzureDeployment, req.Image.AuthMode)
+		_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Image.Provider, "healthy", "ok")
 		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Image.Provider, req.Image.Model, true, "ok")
 		dtoRequest.ResponseSuccess(c, gin.H{"ok": true})
 	case contract.ModEmbed:
@@ -306,10 +565,13 @@ func (h *AgentSettingHandler) testConnection(c *gin.Context) {
 			return
 		}
 		if err := h.svc.PingGeneric(c.Request.Context(), req.Env, tenantRef, req.Modality, req.Embedding.Provider, req.Embedding.Model, req.Embedding.BaseURL, req.Embedding.APIKey); err != nil {
+			_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Embedding.Provider, "unhealthy", err.Error())
 			h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Embedding.Provider, req.Embedding.Model, false, err.Error())
 			dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		_ = saveVerifiedCredential(req.Embedding.Provider, req.Embedding.APIKey, "", "", req.Embedding.BaseURL, req.Embedding.Region, req.Embedding.Organization, req.Embedding.AzureDeployment, req.Embedding.AuthMode)
+		_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Embedding.Provider, "healthy", "ok")
 		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Embedding.Provider, req.Embedding.Model, true, "ok")
 		dtoRequest.ResponseSuccess(c, gin.H{"ok": true})
 	case contract.ModVideo:
@@ -318,11 +580,29 @@ func (h *AgentSettingHandler) testConnection(c *gin.Context) {
 			return
 		}
 		if err := h.svc.PingGeneric(c.Request.Context(), req.Env, tenantRef, req.Modality, req.Video.Provider, req.Video.Model, req.Video.BaseURL, req.Video.APIKey); err != nil {
+			_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Video.Provider, "unhealthy", err.Error())
 			h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Video.Provider, req.Video.Model, false, err.Error())
 			dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		_ = saveVerifiedCredential(req.Video.Provider, req.Video.APIKey, "", "", req.Video.BaseURL, req.Video.Region, req.Video.Organization, req.Video.AzureDeployment, req.Video.AuthMode)
+		_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Video.Provider, "healthy", "ok")
 		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Video.Provider, req.Video.Model, true, "ok")
+		dtoRequest.ResponseSuccess(c, gin.H{"ok": true})
+	case contract.ModModel3D:
+		if req.Model3D == nil {
+			dtoRequest.ResponseError(c, http.StatusBadRequest, "model3d 配置不能为空", nil)
+			return
+		}
+		if err := h.svc.PingGeneric(c.Request.Context(), req.Env, tenantRef, req.Modality, req.Model3D.Provider, req.Model3D.Model, req.Model3D.BaseURL, req.Model3D.APIKey); err != nil {
+			_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Model3D.Provider, "unhealthy", err.Error())
+			h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Model3D.Provider, req.Model3D.Model, false, err.Error())
+			dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
+			return
+		}
+		_ = saveVerifiedCredential(req.Model3D.Provider, req.Model3D.APIKey, req.Model3D.SecretID, req.Model3D.SecretKey, req.Model3D.BaseURL, req.Model3D.Region, req.Model3D.Organization, req.Model3D.AzureDeployment, req.Model3D.AuthMode)
+		_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Model3D.Provider, "healthy", "ok")
+		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Model3D.Provider, req.Model3D.Model, true, "ok")
 		dtoRequest.ResponseSuccess(c, gin.H{"ok": true})
 	case contract.ModAudioTTS:
 		if req.AudioTTS == nil {
@@ -330,10 +610,13 @@ func (h *AgentSettingHandler) testConnection(c *gin.Context) {
 			return
 		}
 		if err := h.svc.PingGeneric(c.Request.Context(), req.Env, tenantRef, req.Modality, req.AudioTTS.Provider, req.AudioTTS.Model, req.AudioTTS.BaseURL, req.AudioTTS.APIKey); err != nil {
+			_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.AudioTTS.Provider, "unhealthy", err.Error())
 			h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.AudioTTS.Provider, req.AudioTTS.Model, false, err.Error())
 			dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		_ = saveVerifiedCredential(req.AudioTTS.Provider, req.AudioTTS.APIKey, "", "", req.AudioTTS.BaseURL, req.AudioTTS.Region, req.AudioTTS.Organization, req.AudioTTS.AzureDeployment, req.AudioTTS.AuthMode)
+		_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.AudioTTS.Provider, "healthy", "ok")
 		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.AudioTTS.Provider, req.AudioTTS.Model, true, "ok")
 		dtoRequest.ResponseSuccess(c, gin.H{"ok": true})
 	case contract.ModAudioASR:
@@ -342,10 +625,13 @@ func (h *AgentSettingHandler) testConnection(c *gin.Context) {
 			return
 		}
 		if err := h.svc.PingGeneric(c.Request.Context(), req.Env, tenantRef, req.Modality, req.AudioASR.Provider, req.AudioASR.Model, req.AudioASR.BaseURL, req.AudioASR.APIKey); err != nil {
+			_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.AudioASR.Provider, "unhealthy", err.Error())
 			h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.AudioASR.Provider, req.AudioASR.Model, false, err.Error())
 			dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		_ = saveVerifiedCredential(req.AudioASR.Provider, req.AudioASR.APIKey, "", "", req.AudioASR.BaseURL, req.AudioASR.Region, req.AudioASR.Organization, req.AudioASR.AzureDeployment, req.AudioASR.AuthMode)
+		_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.AudioASR.Provider, "healthy", "ok")
 		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.AudioASR.Provider, req.AudioASR.Model, true, "ok")
 		dtoRequest.ResponseSuccess(c, gin.H{"ok": true})
 	case contract.ModRerank:
@@ -354,10 +640,13 @@ func (h *AgentSettingHandler) testConnection(c *gin.Context) {
 			return
 		}
 		if err := h.svc.PingGeneric(c.Request.Context(), req.Env, tenantRef, req.Modality, req.Rerank.Provider, req.Rerank.Model, req.Rerank.BaseURL, req.Rerank.APIKey); err != nil {
+			_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Rerank.Provider, "unhealthy", err.Error())
 			h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Rerank.Provider, req.Rerank.Model, false, err.Error())
 			dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		_ = saveVerifiedCredential(req.Rerank.Provider, req.Rerank.APIKey, "", "", req.Rerank.BaseURL, req.Rerank.Region, req.Rerank.Organization, req.Rerank.AzureDeployment, req.Rerank.AuthMode)
+		_ = h.svc.UpsertTenantProviderHealth(c.Request.Context(), tenantUUID, req.Env, string(req.Modality), req.Rerank.Provider, "healthy", "ok")
 		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestConnection, req.Modality, req.Rerank.Provider, req.Rerank.Model, true, "ok")
 		dtoRequest.ResponseSuccess(c, gin.H{"ok": true})
 	default:
@@ -387,7 +676,7 @@ func (h *AgentSettingHandler) testQuickCall(c *gin.Context) {
 		out, err := h.svc.QuickCallLLM(
 			c.Request.Context(),
 			req.Env, tenantRef,
-			req.LLM.Provider, req.LLM.Model, req.LLM.BaseURL, req.LLM.APIKey,
+			req.LLM.Provider, req.LLM.Model, req.LLM.BaseURL, req.LLM.APIKey, req.LLM.SecretID, req.LLM.SecretKey, req.LLM.Region, req.LLM.AuthMode,
 			req.LLM.Temperature, req.LLM.MaxTokens,
 			req.Prompt,
 		)
@@ -436,6 +725,19 @@ func (h *AgentSettingHandler) testQuickCall(c *gin.Context) {
 		}
 		msg := describeVideoQuickCall(req.Video, req.Prompt)
 		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestQuickCall, req.Modality, req.Video.Provider, req.Video.Model, true, msg)
+		dtoRequest.ResponseSuccess(c, gin.H{"ok": true, "result": msg})
+	case contract.ModModel3D:
+		if req.Model3D == nil {
+			dtoRequest.ResponseError(c, http.StatusBadRequest, "model3d 配置不能为空", nil)
+			return
+		}
+		if err := h.svc.PingGeneric(c.Request.Context(), req.Env, tenantRef, req.Modality, req.Model3D.Provider, req.Model3D.Model, req.Model3D.BaseURL, req.Model3D.APIKey); err != nil {
+			h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestQuickCall, req.Modality, req.Model3D.Provider, req.Model3D.Model, false, err.Error())
+			dtoRequest.ResponseSuccess(c, gin.H{"ok": false, "message": err.Error()})
+			return
+		}
+		msg := describeModel3DQuickCall(req.Model3D, req.Prompt)
+		h.emitAuditEvent(c, tenantUUID, req.Env, auditOpTestQuickCall, req.Modality, req.Model3D.Provider, req.Model3D.Model, true, msg)
 		dtoRequest.ResponseSuccess(c, gin.H{"ok": true, "result": msg})
 	case contract.ModAudioTTS:
 		if req.AudioTTS == nil {
@@ -502,6 +804,9 @@ func buildEntitiesFromPayload(req *saveSettingsReq, tenantUUID *string) (credNam
 		credName = utils.Slug(req.Env + "-" + req.LLM.Provider) // e.g. "default-ollama"
 		cred = datatypes.JSONMap{
 			"api_key":          req.LLM.APIKey, // 允许为空（本地 ollama 不需要）
+			"secret_id":        req.LLM.SecretID,
+			"secret_key":       req.LLM.SecretKey,
+			"auth_mode":        req.LLM.AuthMode,
 			"base_url":         req.LLM.BaseURL,
 			"region":           req.LLM.Region,
 			"organization":     req.LLM.Organization,
@@ -535,6 +840,9 @@ func buildEntitiesFromPayload(req *saveSettingsReq, tenantUUID *string) (credNam
 		credName = utils.Slug(req.Env + "-" + req.Image.Provider)
 		cred = datatypes.JSONMap{
 			"api_key":          req.Image.APIKey,
+			"secret_id":        req.Image.SecretID,
+			"secret_key":       req.Image.SecretKey,
+			"auth_mode":        req.Image.AuthMode,
 			"base_url":         req.Image.BaseURL,
 			"region":           req.Image.Region,
 			"organization":     req.Image.Organization,
@@ -568,6 +876,9 @@ func buildEntitiesFromPayload(req *saveSettingsReq, tenantUUID *string) (credNam
 		credName = utils.Slug(req.Env + "-" + req.Embedding.Provider)
 		cred = datatypes.JSONMap{
 			"api_key":          req.Embedding.APIKey,
+			"secret_id":        req.Embedding.SecretID,
+			"secret_key":       req.Embedding.SecretKey,
+			"auth_mode":        req.Embedding.AuthMode,
 			"base_url":         req.Embedding.BaseURL,
 			"region":           req.Embedding.Region,
 			"organization":     req.Embedding.Organization,
@@ -600,6 +911,9 @@ func buildEntitiesFromPayload(req *saveSettingsReq, tenantUUID *string) (credNam
 		credName = utils.Slug(req.Env + "-" + req.Video.Provider)
 		cred = datatypes.JSONMap{
 			"api_key":          req.Video.APIKey,
+			"secret_id":        req.Video.SecretID,
+			"secret_key":       req.Video.SecretKey,
+			"auth_mode":        req.Video.AuthMode,
 			"base_url":         req.Video.BaseURL,
 			"region":           req.Video.Region,
 			"organization":     req.Video.Organization,
@@ -619,6 +933,39 @@ func buildEntitiesFromPayload(req *saveSettingsReq, tenantUUID *string) (credNam
 			},
 			Tags: []string{"video"},
 		}
+	case contract.ModModel3D:
+		if req.Model3D == nil {
+			return
+		}
+		p := strings.TrimSpace(req.Model3D.Provider)
+		m := strings.TrimSpace(req.Model3D.Model)
+		if p == "" || m == "" {
+			return
+		}
+		credProvider = req.Model3D.Provider
+		credName = utils.Slug(req.Env + "-" + req.Model3D.Provider)
+		cred = datatypes.JSONMap{
+			"api_key":          req.Model3D.APIKey,
+			"secret_id":        req.Model3D.SecretID,
+			"secret_key":       req.Model3D.SecretKey,
+			"auth_mode":        req.Model3D.AuthMode,
+			"base_url":         req.Model3D.BaseURL,
+			"region":           req.Model3D.Region,
+			"organization":     req.Model3D.Organization,
+			"azure_deployment": req.Model3D.AzureDeployment,
+		}
+		prof = &dbmodel.AIModelProfile{
+			Env:        req.Env,
+			TenantUUID: tenantUUID,
+			Modality:   "model3d",
+			Provider:   req.Model3D.Provider,
+			Model:      req.Model3D.Model,
+			Defaults: datatypes.JSONMap{
+				"outputFormat": req.Model3D.OutputFormat,
+				"promptHint":   req.Model3D.PromptHint,
+			},
+			Tags: []string{"model3d"},
+		}
 
 	case contract.ModAudioTTS:
 		if req.AudioTTS == nil {
@@ -633,6 +980,9 @@ func buildEntitiesFromPayload(req *saveSettingsReq, tenantUUID *string) (credNam
 		credName = utils.Slug(req.Env + "-" + req.AudioTTS.Provider)
 		cred = datatypes.JSONMap{
 			"api_key":          req.AudioTTS.APIKey,
+			"secret_id":        req.AudioTTS.SecretID,
+			"secret_key":       req.AudioTTS.SecretKey,
+			"auth_mode":        req.AudioTTS.AuthMode,
 			"base_url":         req.AudioTTS.BaseURL,
 			"region":           req.AudioTTS.Region,
 			"organization":     req.AudioTTS.Organization,
@@ -666,6 +1016,9 @@ func buildEntitiesFromPayload(req *saveSettingsReq, tenantUUID *string) (credNam
 		credName = utils.Slug(req.Env + "-" + req.AudioASR.Provider)
 		cred = datatypes.JSONMap{
 			"api_key":          req.AudioASR.APIKey,
+			"secret_id":        req.AudioASR.SecretID,
+			"secret_key":       req.AudioASR.SecretKey,
+			"auth_mode":        req.AudioASR.AuthMode,
 			"base_url":         req.AudioASR.BaseURL,
 			"region":           req.AudioASR.Region,
 			"organization":     req.AudioASR.Organization,
@@ -699,6 +1052,9 @@ func buildEntitiesFromPayload(req *saveSettingsReq, tenantUUID *string) (credNam
 		credName = utils.Slug(req.Env + "-" + req.Rerank.Provider)
 		cred = datatypes.JSONMap{
 			"api_key":          req.Rerank.APIKey,
+			"secret_id":        req.Rerank.SecretID,
+			"secret_key":       req.Rerank.SecretKey,
+			"auth_mode":        req.Rerank.AuthMode,
 			"base_url":         req.Rerank.BaseURL,
 			"region":           req.Rerank.Region,
 			"organization":     req.Rerank.Organization,
@@ -734,6 +1090,11 @@ func describeEmbeddingQuickCall(m *modEmbed) string {
 func describeVideoQuickCall(m *modVideo, prompt string) string {
 	return fmt.Sprintf("已校验 Video provider=%s model=%s res=%s fps=%d maxDuration=%ds prompt=%s",
 		m.Provider, m.Model, defaultIfEmpty(m.Resolution, "720p"), m.FPS, m.MaxDurationSec, snippet(prompt, 60))
+}
+
+func describeModel3DQuickCall(m *modModel3D, prompt string) string {
+	return fmt.Sprintf("已校验 3D provider=%s model=%s outputFormat=%s prompt=%s",
+		m.Provider, m.Model, defaultIfEmpty(m.OutputFormat, "glb"), snippet(prompt, 60))
 }
 
 func describeAudioTTSQuickCall(m *modAudioTTS, prompt string) string {
@@ -800,6 +1161,56 @@ func (h *AgentSettingHandler) getActiveProfile(c *gin.Context) {
 		"profile":    prof, // ✅ 只有一条
 		"configured": true,
 	})
+}
+
+type setCurrentEnvReq struct {
+	Env string `json:"env" validate:"required"`
+}
+
+func (h *AgentSettingHandler) getCurrentEnv(c *gin.Context) {
+	tenantCtx, err := requireTenantContext(c)
+	if err != nil {
+		dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+	tenantUUID := tenantCtx.UUID()
+	env, configured, err := h.svc.GetTenantCurrentAIEnv(c.Request.Context(), tenantUUID)
+	if err != nil {
+		dtoRequest.ResponseError(c, http.StatusInternalServerError, "查询失败", err)
+		return
+	}
+	if !configured {
+		dtoRequest.ResponseSuccess(c, gin.H{
+			"configured": false,
+			"env":        "",
+			"fallback":   "dev",
+			"message":    "租户尚未设置当前 AI 环境，将使用默认值。",
+		})
+		return
+	}
+	dtoRequest.ResponseSuccess(c, gin.H{
+		"configured": true,
+		"env":        env,
+	})
+}
+
+func (h *AgentSettingHandler) setCurrentEnv(c *gin.Context) {
+	var req setCurrentEnvReq
+	if err := dtoRequest.ValidateRequestWithContext(c, &req); err != nil {
+		dtoRequest.ResponseValidationError(c, err)
+		return
+	}
+	tenantCtx, err := requireTenantContext(c)
+	if err != nil {
+		dtoRequest.ResponseError(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+	tenantUUID := tenantCtx.UUID()
+	if err := h.svc.SetTenantCurrentAIEnv(c.Request.Context(), tenantUUID, req.Env); err != nil {
+		dtoRequest.ResponseError(c, http.StatusBadRequest, "设置失败", err)
+		return
+	}
+	dtoRequest.ResponseSuccess(c, gin.H{"ok": true, "env": req.Env})
 }
 
 type setActiveReq struct {

--- a/backend/pkg/dto/stream_events.go
+++ b/backend/pkg/dto/stream_events.go
@@ -4,6 +4,7 @@ package dto
 // 传输无关（SSE/WS 共用的事件名）
 const (
 	EventStart     = "start"
+	EventMeta      = "meta"
 	EventIntent    = "intent"
 	EventPlan      = "plan"
 	EventToken     = "token"

--- a/docs/guides/agent/ai_setting.md
+++ b/docs/guides/agent/ai_setting.md
@@ -4,8 +4,18 @@ PowerX 的「AI 设置」页面提供了统一的 Provider/模型管理；理解
 
 ## 默认配置
 
-1. **后端默认值**：若从未在后台保存任何配置，Agent 将使用 `backend/etc/config_example.yaml` 中 `ai.defaults` 段配置的 provider / model / endpoint。这是编译期的静态兜底，适合本地开发。
+1. **开发期种子默认值**：`backend/etc/config_example.yaml` 的 `ai.defaults` 主要用于“本地开发/初次启动”的演示默认（例如默认选中哪个 provider/model）。在生产环境里，如果数据库里没有保存任何 AI Settings（含凭据），系统应提示用户先完成安装/配置，而不是静默使用 config.yaml 的值继续执行。
 2. **环境隔离**：页面左侧的环境切换（默认 `default`）会把不同环境的数据保存在各自的 scope 下，后端通过 `env + tenant` 二元索引区分，同一个 provider 可以在不同环境配置不同的 key。
+
+## 聊天时的 LLM 生效优先级（人话版）
+
+一次“发送消息”真正用哪个 provider/model/参数，会按从高到低依次覆盖：
+
+1. **Flow 节点级配置（node params）**：某个 flow 的某个 LLM 节点写死的参数（例如强制 `model=xxx`）。这是最高优先级。
+2. **本次请求临时配置（ChatConfig）**：前端在本次发送里临时指定（例如用户临时切模型/温度），只影响这一次或这一会话。
+3. **智能体自身配置（AgentSetting，DB）**：在「智能体配置」里给某个智能体单独设置的 provider/model（以及可选参数），只影响这个智能体。
+4. **AI Settings 默认（Active Profile，DB）**：在「AI 设置」里选中的默认 provider/model（按 env + tenant 隔离），作为系统默认。
+5. **开发期种子默认（config.yaml）**：仅用于没有任何 DB 配置时的“演示默认”。如果缺少凭据/不可连通，运行时应返回明确错误并引导去 AI Settings 配置。
 
 ## 保存一次 = 落两个实体
 
@@ -27,6 +37,13 @@ PowerX 的「AI 设置」页面提供了统一的 Provider/模型管理；理解
 3. 点击「保存」。这一步不仅更新 profile/credential，还会把该 provider/model 写入默认路由，后端随即改用新的组合。
 
 > ⚠️ **仅切换下拉框不生效**：如果你仅切换 provider 但没有点击「保存」，前端状态会改变，但数据库里的默认路由不会更新，Agent 仍然调用旧模型。
+
+## 智能体级覆盖（AgentSetting）
+
+如果你希望某个智能体使用不同于系统默认的模型（例如“营销智能体用 deepseek-reasoner、客服智能体用 gpt-4o-mini”），请在智能体的配置面板里设置 provider/model（并保存）。
+
+- 这会写入 `agent_settings`（按 env + tenant + agent 作用域）
+- 运行时会先读取 AI Settings 的默认，再读取该智能体的覆盖；如果智能体选择“系统默认”，则会删除该覆盖记录并回退到 AI Settings 默认
 
 ## 多 provider 场景
 

--- a/docs/guides/develop/web_admin_troubleshooting.md
+++ b/docs/guides/develop/web_admin_troubleshooting.md
@@ -1,0 +1,19 @@
+# Web Admin 常见故障排查
+
+## 刷新后卡死 / 一直 Loading
+
+如果浏览器控制台出现类似错误：
+
+- `Uncaught (in promise) Error: Could not establish connection. Receiving end does not exist.`
+- `The message port closed before a response was received.`
+
+通常原因是**浏览器扩展**向页面注入脚本，并通过 message channel 与自身通信；在刷新/路由切换时 receiver 不存在，就会抛出上述错误。该错误本身与 PowerX 功能无关，但可能触发前端全局错误处理，导致 Loading 状态无法正确结束。
+
+处理建议：
+
+1. 先在无痕窗口打开 Web Admin（默认禁用大多数扩展）验证是否消失。
+2. 若确认是扩展导致，逐个禁用扩展定位（常见：翻译/脚本管理/隐私保护/代理/开发辅助类扩展）。
+3. 开发环境可使用“硬刷新（Disable cache + Reload）”避免旧脚本残留。
+
+PowerX Web Admin 已对这些“已知扩展错误”做了忽略处理（不再让其导致页面卡死），但最佳实践仍是：在调试期尽量关闭不必要的扩展，以免干扰排查。
+

--- a/web-admin/app/app.vue
+++ b/web-admin/app/app.vue
@@ -17,6 +17,8 @@ onMounted(() => {
   // 800ms 后确保隐藏
   setTimeout(() => {
     gl.hide();
+    gl.setMessage("加载中…");
+    gl.setProgress(undefined);
     // 重置所有状态，确保完全清理
     const lockCount = useGL_LockCount();
     const manualVisible = useGL_ManualVisible();

--- a/web-admin/app/components/agent/AgentMarkdown.vue
+++ b/web-admin/app/components/agent/AgentMarkdown.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { parseMarkdown, createCachedParser } from "@nuxtjs/mdc/runtime";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    source: string;
+    streaming?: boolean;
+  }>(),
+  {
+    source: "",
+    streaming: false,
+  }
+);
+
+type Parsed = {
+  body: any;
+  data?: any;
+};
+
+const collapseInlineCodeLines = (md: string) => {
+  const src = String(md ?? "").replace(/\r\n/g, "\n");
+  const lines = src.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const m = lines[i].match(/^\s*`([^`]+)`\s*$/);
+    if (!m) {
+      out.push(lines[i]);
+      i++;
+      continue;
+    }
+    const run: string[] = [m[1]];
+    let j = i + 1;
+    while (j < lines.length) {
+      const mj = lines[j].match(/^\s*`([^`]+)`\s*$/);
+      if (!mj) break;
+      run.push(mj[1]);
+      j++;
+    }
+    if (run.length >= 2) {
+      out.push("```");
+      out.push(...run);
+      out.push("```");
+    } else {
+      out.push(lines[i]);
+    }
+    i = j;
+  }
+  return out.join("\n");
+};
+
+const normalizedSource = computed(() => collapseInlineCodeLines(props.source));
+
+const parsed = ref<Parsed | null>(null);
+const parseErr = ref<string>("");
+
+// 流式时用增量 parser（只要内容是 append，就能更省开销）
+const incrementalParse = createCachedParser({});
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+const clearTimer = () => {
+  if (timer) clearTimeout(timer);
+  timer = null;
+};
+onBeforeUnmount(() => clearTimer());
+
+const doParse = async () => {
+  const src = normalizedSource.value || "";
+  if (!src.trim()) {
+    parsed.value = null;
+    parseErr.value = "";
+    return;
+  }
+  try {
+    parseErr.value = "";
+    const res = props.streaming
+      ? await incrementalParse(src)
+      : await parseMarkdown(src, {
+          // 让 @nuxtjs/mdc 走它自带的 rehype-highlight/shiki 配置
+          //（由 Nuxt Content/配置决定）
+        });
+    parsed.value = (res as any) || null;
+  } catch (e) {
+    parsed.value = null;
+    parseErr.value = e instanceof Error ? e.message : String(e);
+  }
+};
+
+watch(
+  () => [normalizedSource.value, props.streaming] as const,
+  async () => {
+    clearTimer();
+    // 流式时做轻微 debounce，避免每个 token 都触发一次 parse
+    timer = setTimeout(() => void doParse(), props.streaming ? 120 : 0);
+  },
+  { immediate: true }
+);
+</script>
+
+<template>
+  <div class="px-md">
+    <MDCRenderer v-if="parsed?.body" :body="parsed.body" :data="parsed.data" prose />
+    <pre v-else-if="parseErr" class="px-md__fallback">{{ source }}</pre>
+  </div>
+</template>
+
+<style scoped>
+.px-md {
+  width: 100%;
+}
+.px-md__fallback {
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+</style>
+

--- a/web-admin/app/components/agent/AgentSidebar.vue
+++ b/web-admin/app/components/agent/AgentSidebar.vue
@@ -357,11 +357,13 @@ function fmtTime(ts?: string | number | Date) {
                           label: t('agent.selector.unpin') || '取消置顶',
                           icon: 'i-heroicons-bookmark-slash',
                           click: () => onTogglePin(s.id, false),
+                          onSelect: () => onTogglePin(s.id, false),
                         },
                         {
                           label: t('agent.selector.rename') || '重命名',
                           icon: 'i-heroicons-pencil',
                           click: () => onRenameSession(s.id),
+                          onSelect: () => onRenameSession(s.id),
                         },
                       ],
                       [
@@ -370,6 +372,7 @@ function fmtTime(ts?: string | number | Date) {
                           icon: 'i-heroicons-trash',
                           color: 'error',
                           click: () => onDeleteSession(s.id),
+                          onSelect: () => onDeleteSession(s.id),
                         },
                       ],
                     ]"
@@ -451,11 +454,13 @@ function fmtTime(ts?: string | number | Date) {
                           label: t('agent.selector.pin') || '置顶',
                           icon: 'i-heroicons-bookmark',
                           click: () => onTogglePin(s.id, true),
+                          onSelect: () => onTogglePin(s.id, true),
                         },
                         {
                           label: t('agent.selector.rename') || '重命名',
                           icon: 'i-heroicons-pencil',
                           click: () => onRenameSession(s.id),
+                          onSelect: () => onRenameSession(s.id),
                         },
                       ],
                       [
@@ -464,6 +469,7 @@ function fmtTime(ts?: string | number | Date) {
                           icon: 'i-heroicons-trash',
                           color: 'error',
                           click: () => onDeleteSession(s.id),
+                          onSelect: () => onDeleteSession(s.id),
                         },
                       ],
                     ]"

--- a/web-admin/app/components/agent/ChatInterface.vue
+++ b/web-admin/app/components/agent/ChatInterface.vue
@@ -52,6 +52,7 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: "send-message", content: string): void;
   (e: "retry-message"): void;
+  (e: "regenerate-from", messageId: string | number): void;
   (e: "clear-messages"): void;
 }>();
 
@@ -517,6 +518,7 @@ function onSendClick() {
             "
             :agent-name="currentAgent?.name"
             @retry="$emit('retry-message')"
+            @regenerate="(id) => $emit('regenerate-from', id)"
             @copy="() => {}"
             @delete="() => {}"
           />

--- a/web-admin/app/components/agent/ConfigPanel.vue
+++ b/web-admin/app/components/agent/ConfigPanel.vue
@@ -2,6 +2,10 @@
 import { reactive, watch, ref, computed } from "vue";
 import type { AgentConfig } from "~/composables/agent/useAgentManager";
 import type { Agent } from "~/types/agent";
+import { AISettingService, type Provider } from "~/composables/api/services/aiSettingService";
+import { useSettingsService } from "~/composables/api/services/settingsService";
+import { useApiClient } from "~/composables/api";
+import { useAISettingsStore } from "~/stores/aiSettings";
 
 type AgentConfigEx = AgentConfig & {
   contextWindow?: number;
@@ -26,18 +30,106 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
+const debugPanel = process.env.NUXT_PUBLIC_AGENT_DEBUG === "true";
 
-// ------- 选项 -------
-const modelOptions = [
-  { label: "GPT-4", value: "gpt-4" },
-  { label: "GPT-4 Turbo", value: "gpt-4-turbo" },
-  { label: "GPT-3.5 Turbo", value: "gpt-3.5-turbo" },
-  { label: "Claude-3 Opus", value: "claude-3-opus" },
-  { label: "Claude-3 Sonnet", value: "claude-3-sonnet" },
-  { label: "Claude-3 Haiku", value: "claude-3-haiku" },
-  { label: "Gemini Pro", value: "gemini-pro" },
-  { label: "Gemini Pro Vision", value: "gemini-pro-vision" },
-];
+const ENV = "dev";
+const MODALITY = "llm";
+const { get } = useApiClient();
+
+// ------- Provider/Model 联动数据 -------
+const providers = ref<Provider[]>([]);
+const modelItems = ref<{ label: string; value: string }[]>([]);
+const showOnlyConfigured = ref(true);
+const aiSettingsStore = useAISettingsStore();
+const defaults = reactive<{
+  provider: string;
+  model: string;
+  source: "agent" | "ai-settings" | "config" | "unknown";
+}>({
+  provider: "",
+  model: "",
+  source: "unknown",
+});
+
+const providerItems = computed(() =>
+  (providers.value || []).map((p) => ({
+    label: p.Name || p.ID,
+    value: p.ID,
+  }))
+);
+
+const configuredProviderSet = computed(() => {
+  const creds = aiSettingsStore.credentials || [];
+  const profiles = aiSettingsStore.profiles || [];
+  const set = new Set<string>();
+  for (const prof of profiles) {
+    if (String(prof?.modality || "").toLowerCase() !== MODALITY) continue;
+    const provider = String(prof?.provider || "").trim();
+    if (!provider) continue;
+    const hasCred = creds.some(
+      (c) => String(c?.provider || "").toLowerCase() === provider.toLowerCase()
+    );
+    if (hasCred) set.add(provider);
+  }
+  return set;
+});
+
+const configuredModelsForProvider = computed(() => {
+  const profiles = aiSettingsStore.profiles || [];
+  const map = new Map<string, Set<string>>();
+  for (const prof of profiles) {
+    if (String(prof?.modality || "").toLowerCase() !== MODALITY) continue;
+    const provider = String(prof?.provider || "").trim();
+    const model = String(prof?.model || "").trim();
+    if (!provider || !model) continue;
+    if (!map.has(provider)) map.set(provider, new Set());
+    map.get(provider)!.add(model);
+  }
+  return map;
+});
+
+const filteredProviderItems = computed(() => {
+  const all = providerItems.value || [];
+  if (!showOnlyConfigured.value) return all;
+
+  const allow = configuredProviderSet.value;
+  const filtered = all.filter((it) => allow.has(String(it.value)));
+
+  // 如果当前展示的 provider 不在已配置集合里，也要显示出来，避免 UI 丢失选择
+  const cur = String(effectiveProvider.value || form.provider || "").trim();
+  if (cur && !filtered.some((it) => String(it.value) === cur)) {
+    const hit = all.find((it) => String(it.value) === cur);
+    filtered.unshift(
+      hit
+        ? {
+            ...hit,
+            label: `${hit.label} (${t("agent.config.notConfigured") || "未配置"})`,
+          }
+        : {
+            label: `${cur} (${t("agent.config.notConfigured") || "未配置"})`,
+            value: cur,
+          }
+    );
+  }
+  return filtered;
+});
+
+const showConfiguredEmptyHint = computed(() => {
+  return (
+    showOnlyConfigured.value &&
+    (filteredProviderItems.value || []).length === 0 &&
+    (providerItems.value || []).length > 0
+  );
+});
+
+const effectiveProvider = computed(() => {
+  if (!form.useSystemModelConfig && form.provider) return String(form.provider);
+  return defaults.provider || "";
+});
+const effectiveModel = computed(() => {
+  if (!form.useSystemModelConfig && form.model) return String(form.model);
+  return defaults.model || "";
+});
 
 // 统一的能力字典（用 key 作为 id）
 const capabilityDict = [
@@ -66,7 +158,10 @@ const form = reactive<Partial<AgentConfigEx>>({
   name: "",
   description: "",
   avatar: "",
-  model: "gpt-4",
+  // 模型配置（可选覆盖：provider/model；未覆盖时回退到系统默认）
+  useSystemModelConfig: true,
+  provider: "",
+  model: "",
   systemPrompt: "",
   temperature: 0.7,
   topP: 1,
@@ -86,18 +181,130 @@ const selectedCaps = ref<string[]>([]);
 // 是否编辑：只看 form.id 是否有值
 const isEdit = computed(() => !!form.id && String(form.id).trim() !== "");
 
+async function loadProvidersOnce() {
+  if (providers.value.length) return;
+  providers.value = await AISettingService.getProviders(MODALITY, ENV);
+}
+
+async function ensureAISettingsEnv() {
+  if (!aiSettingsStore.initialized) {
+    await aiSettingsStore.initialize(ENV);
+  }
+  if (aiSettingsStore.currentEnv !== ENV) {
+    await aiSettingsStore.refreshEnvData(ENV, [MODALITY]);
+  } else {
+    // 只拉一次 llm profile/cred，避免无关模态噪声
+    await aiSettingsStore.refreshEnvData(ENV, [MODALITY]);
+  }
+}
+
+async function loadModelsForProvider(provider: string) {
+  const p = String(provider || "").trim();
+  if (!p) {
+    modelItems.value = [];
+    return;
+  }
+  const models = await AISettingService.getModels(p, MODALITY, ENV);
+  const all = (models || []).map((m) => ({ label: m, value: m }));
+
+  if (!showOnlyConfigured.value) {
+    modelItems.value = all;
+    return;
+  }
+
+  const allow = configuredModelsForProvider.value.get(p) || new Set<string>();
+  const filtered = all.filter((it) => allow.has(String(it.value)));
+
+  // 保底：当前选择的 model 不在已配置集合里，也要显示出来（系统默认/自定义都需要）
+  const cur = String(effectiveModel.value || form.model || "").trim();
+  if (cur && !filtered.some((it) => String(it.value) === cur)) {
+    const hit = all.find((it) => String(it.value) === cur);
+    filtered.unshift(
+      hit
+        ? { ...hit, label: `${hit.label} (${t("agent.config.notConfigured") || "未配置"})` }
+        : { label: `${cur} (${t("agent.config.notConfigured") || "未配置"})`, value: cur }
+    );
+  }
+
+  modelItems.value = filtered;
+}
+
+async function resolveSystemDefaults() {
+  // 1) 优先：系统 AI Settings 里“激活”的默认模态配置
+  try {
+    const res = await AISettingService.getActiveProfile(ENV, MODALITY);
+    const prof = res?.data?.profile;
+    if (prof?.provider && prof?.model) {
+      defaults.provider = String(prof.provider);
+      defaults.model = String(prof.model);
+      defaults.source = "ai-settings";
+      return;
+    }
+  } catch {}
+
+  // 2) 兜底：/settings/ai（来自 config.yaml 的系统默认）
+  try {
+    const settingsSvc = useSettingsService();
+    const res = await settingsSvc.getAISettings();
+    const ai = (res as any)?.data;
+    const defProvider = String(ai?.defaultProvider || "").trim();
+    const defModel =
+      String(
+        (ai?.providers || []).find?.((p: any) => p?.id === defProvider)
+          ?.defaultModel || ""
+      ).trim();
+    if (defProvider && defModel) {
+      defaults.provider = defProvider;
+      defaults.model = defModel;
+      defaults.source = "config";
+      return;
+    }
+  } catch {}
+
+  defaults.provider = "";
+  defaults.model = "";
+  defaults.source = "unknown";
+}
+
+async function loadAgentOverride(agentId: number | string) {
+  const id = String(agentId || "").trim();
+  if (!id) return false;
+  try {
+    const res = await get<any>(`/admin/agents/${id}/ai-setting`, {
+      params: { env: ENV },
+      useGlobalLoading: false,
+    });
+    if (res?.code === 200 && res?.data) {
+      const s = res.data as any;
+      const p = String(s.provider || "").trim();
+      const m = String(s.model || "").trim();
+      if (p && m) {
+        form.useSystemModelConfig = false;
+        form.provider = p;
+        await loadModelsForProvider(p);
+        form.model = m;
+        defaults.source = "agent";
+        return true;
+      }
+    }
+  } catch {}
+  return false;
+}
+
 // 把 props.agent → 表单
 watch(
   () => props.agent,
-  (a) => {
-    console.log("[config-panel] incoming agent:", a);
+  async (a) => {
+    if (debugPanel) console.info("[config-panel] incoming agent:", a);
     // 1) 先重置为默认
     Object.assign(form, {
       id: "",
       name: "",
       description: "",
       avatar: "",
-      model: "gpt-4",
+      useSystemModelConfig: true,
+      provider: "",
+      model: "",
       systemPrompt: "",
       temperature: 0.7,
       topP: 1,
@@ -127,7 +334,7 @@ watch(
             : true;
 
       // 可选：如果前端传了高级字段就用前端的
-      form.model = anyA.model ?? form.model;
+      // 注意：真正落库的是 Agent AI Setting（/admin/agents/:id/ai-setting）
       form.systemPrompt = anyA.systemPrompt ?? form.systemPrompt;
       form.temperature = anyA.temperature ?? form.temperature;
       form.topP = anyA.topP ?? form.topP;
@@ -155,8 +362,74 @@ watch(
       // 创建态：清空选择
       selectedCaps.value = [];
     }
+
+    // 3) 初始化 provider/model：按 你定义的三层回退规则
+    try {
+      await loadProvidersOnce();
+      await ensureAISettingsEnv();
+      await resolveSystemDefaults();
+
+      const hasOverride = form.id ? await loadAgentOverride(form.id) : false;
+      if (!hasOverride) {
+        form.useSystemModelConfig = true;
+        form.provider = defaults.provider;
+        await loadModelsForProvider(defaults.provider);
+        form.model = defaults.model;
+      }
+    } catch (e) {
+      console.warn("[config-panel] init provider/model failed:", e);
+    }
   },
   { immediate: true }
+);
+
+watch(
+  () => form.useSystemModelConfig,
+  async (useDefault) => {
+    if (useDefault) {
+      // 切回“系统默认”时，把显示值回填为默认（但保存时会走 delete override）
+      form.provider = defaults.provider;
+      await loadModelsForProvider(defaults.provider);
+      form.model = defaults.model;
+      return;
+    }
+    // 切到“自定义”时：确保 provider/model 有值，并刷新 models
+    if (!String(form.provider || "").trim()) {
+      form.provider = defaults.provider;
+    }
+    await loadModelsForProvider(String(form.provider || "").trim());
+    if (!String(form.model || "").trim()) {
+      form.model = modelItems.value[0]?.value || defaults.model || "";
+    }
+  }
+);
+
+watch(
+  () => showOnlyConfigured.value,
+  async () => {
+    // 切换筛选模式后，重新拉一次 model 列表以应用过滤规则
+    const p = String(form.provider || defaults.provider || "").trim();
+    if (!p) return;
+    await loadModelsForProvider(p);
+  }
+);
+
+watch(
+  () => form.provider,
+  async (p, prev) => {
+    if (form.useSystemModelConfig) return;
+    const cur = String(p || "").trim();
+    const old = String(prev || "").trim();
+    if (cur === old) return;
+    await loadModelsForProvider(cur);
+    // provider 变更时，如果当前 model 不在新列表里，重置为第一项
+    if (cur && modelItems.value.length) {
+      const hit = modelItems.value.some((it) => it.value === form.model);
+      if (!hit) {
+        form.model = modelItems.value[0]?.value || "";
+      }
+    }
+  }
 );
 
 // 名称 → key（兜底用）
@@ -231,7 +504,9 @@ function resetForm() {
     form.description = a.description ?? "";
     form.isActive = a.status ? a.status === "active" : true;
     // 其余字段按需回填/保持默认
-    form.model = a.model ?? "gpt-4";
+    form.useSystemModelConfig = true;
+    form.provider = defaults.provider;
+    form.model = defaults.model;
     form.systemPrompt = a.systemPrompt ?? "";
     form.temperature = a.temperature ?? 0.7;
     form.topP = a.topP ?? 1;
@@ -249,7 +524,9 @@ function resetForm() {
       name: "",
       description: "",
       avatar: "",
-      model: "gpt-4",
+      useSystemModelConfig: true,
+      provider: defaults.provider,
+      model: defaults.model,
       systemPrompt: "",
       temperature: 0.7,
       topP: 1,
@@ -362,10 +639,55 @@ function cancelConfig() {
               {{ t("agent.config.modelConfig") }}
             </h3>
 
+            <UFormField :label="t('agent.config.onlyShowConfigured') || '仅显示已配置（测试通过）'">
+              <div class="flex items-center justify-between gap-3">
+                <USwitch
+                  v-model="showOnlyConfigured"
+                  :label="
+                    showOnlyConfigured
+                      ? (t('agent.config.onlyConfigured') || '仅已配置')
+                      : (t('agent.config.showAll') || '显示全部')
+                  "
+                />
+                <div v-if="showConfiguredEmptyHint" class="text-xs text-amber-500">
+                  {{ t("agent.config.noConfiguredHint") || "暂无已配置项，已配置筛选可能为空" }}
+                </div>
+              </div>
+            </UFormField>
+
+            <UFormField :label="t('agent.config.useSystemModelConfig') || '使用系统默认'">
+              <div class="flex items-center justify-between gap-3">
+                <USwitch
+                  v-model="form.useSystemModelConfig"
+                  :label="
+                    form.useSystemModelConfig
+                      ? (t('agent.config.inheritEnabled') || '已启用')
+                      : (t('agent.config.inheritDisabled') || '已关闭')
+                  "
+                />
+                <div class="text-xs text-gray-500 truncate">
+                  <span v-if="effectiveProvider && effectiveModel">
+                    {{ effectiveProvider }}/{{ effectiveModel }}
+                  </span>
+                </div>
+              </div>
+            </UFormField>
+
+            <UFormField :label="t('agent.config.selectProvider') || '选择提供商'">
+              <USelect
+                v-model="form.provider"
+                :items="filteredProviderItems"
+                :disabled="!!form.useSystemModelConfig"
+                :placeholder="t('agent.config.selectProvider')"
+                class="w-full"
+              />
+            </UFormField>
+
             <UFormField :label="t('agent.config.model')">
               <USelect
                 v-model="form.model"
-                :items="modelOptions"
+                :items="modelItems"
+                :disabled="!!form.useSystemModelConfig || !form.provider"
                 :placeholder="t('agent.config.selectModel')"
                 class="w-full"
               />

--- a/web-admin/app/components/agent/MessageItem.vue
+++ b/web-admin/app/components/agent/MessageItem.vue
@@ -7,6 +7,7 @@ import { useI18n } from "#imports";
 import { useThinkParser } from "~/composables/agent/useThinkParser";
 import { useMessageTypewriter } from "~/composables/agent/useTypewriter";
 import ThinkBlock from "~/components/agent/ThinkBlock.vue";
+import AgentMarkdown from "~/components/agent/AgentMarkdown.vue";
 import { MESSAGE_TYPES } from "~/types/message";
 
 declare global {
@@ -25,9 +26,19 @@ const emit = defineEmits<{
   (e: "retry"): void;
   (e: "copy", content: string): void;
   (e: "delete"): void;
+  (e: "regenerate", messageId: string | number): void;
 }>();
 
 const { t } = useI18n();
+
+const canRegenerateFromThisUserMessage = computed(() => {
+  const m: any = props.message as any;
+  if (m?.role !== "user") return false;
+  // 仅支持已落库的消息 id（number 或纯数字字符串）
+  if (typeof m?.id === "number") return true;
+  if (typeof m?.id === "string" && /^\d+$/.test(m.id)) return true;
+  return false;
+});
 
 // 原始完整文本
 const normalizedRawContent = computed(() => {
@@ -270,6 +281,16 @@ const processedContent = computed<MessageContent[]>(() => {
   return text ? [{ type: MESSAGE_TYPES.TEXT, data: { text } }] : [];
 });
 
+const isAwaitingFirstContent = computed(() => {
+  const m: any = props.message as any;
+  if (props.message.role !== "assistant") return false;
+  if (m?.isError) return false;
+  const streaming = !!(m?.isStreaming || props.isStreaming);
+  if (!streaming) return false;
+  const content = String(normalizedRawContent.value || "").trim();
+  return content.length === 0;
+});
+
 // 工具函数 & 展示辅助
 const copyToClipboard = async (text: string) => {
   try {
@@ -325,73 +346,6 @@ const openExternalLink = (url: string) => {
 };
 const downloadFile = (url: string, downloadUrl?: string) => {
   if (typeof window !== "undefined") window.open(downloadUrl || url, "_blank");
-};
-
-// 简单 Markdown 渲染（保持你的原逻辑）
-const renderMarkdown = (markdown: string) => {
-  let html = markdown;
-
-  // 1) 标题：允许最多 3 个空格缩进 & 允许 # 号后无空格
-  //    例：###1. 生死观  或  ### 1. 生死观  都能匹配
-  html = html.replace(
-    /^\s{0,3}(#{1,6})\s*(.*)$/gm,
-    (_m, hashes: string, text: string) => {
-      const level = Math.min(hashes.length, 6);
-      return `<h${level}>${text.trim()}</h${level}>`;
-    }
-  );
-
-  // 2) 粗体 / 斜体 / 行内代码 / 链接（保持你的原逻辑）
-  html = html.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>");
-  html = html.replace(/\*(.*?)\*/g, "<em>$1</em>");
-  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
-  html = html.replace(
-    /\[([^\]]+)\]\(([^)]+)\)/g,
-    '<a href="$2" target="_blank" class="text-blue-600 hover:underline">$1</a>'
-  );
-
-  // 3) 引用（允许缩进）
-  html = html.replace(/^\s*>\s+(.*)$/gm, "<blockquote>$1</blockquote>");
-
-  // 4) 表格（保持你的原逻辑）
-  const tableRegex = /\|(.+)\|\n\|[-\s|:]+\|\n((?:\|.+\|\n?)*)/g;
-  html = html.replace(tableRegex, (match, header, rows) => {
-    const headerCells = String(header)
-      .split("|")
-      .map((c: string) => c.trim())
-      .filter(Boolean);
-    const headerRow =
-      "<tr>" +
-      headerCells.map((c: string) => `<th>${c}</th>`).join("") +
-      "</tr>";
-    const bodyRows = String(rows)
-      .trim()
-      .split("\n")
-      .map((row: string) => {
-        const cells = row
-          .split("|")
-          .map((c: string) => c.trim())
-          .filter(Boolean);
-        return (
-          "<tr>" + cells.map((c: string) => `<td>${c}</td>`).join("") + "</tr>"
-        );
-      })
-      .join("");
-    return `<table class="border-collapse border border-gray-300"><thead>${headerRow}</thead><tbody>${bodyRows}</tbody></table>`;
-  });
-
-  // 5) 无序列表：允许缩进（- * +），先每行各自包一层 <ul>，再合并相邻的 <ul>
-  html = html.replace(/^\s*[-*+]\s+(.*)$/gm, "<ul><li>$1</li></ul>");
-  html = html.replace(/<\/ul>\s*<ul>/g, "");
-
-  // 6) 有序列表：允许缩进（1. 2. ...），同样先包 <ol> 再合并
-  html = html.replace(/^\s*\d+\.\s+(.*)$/gm, "<ol><li>$1</li></ol>");
-  html = html.replace(/<\/ol>\s*<ol>/g, "");
-
-  // 7) 换行（放到最后）
-  html = html.replace(/\n/g, "<br>");
-
-  return html;
 };
 </script>
 
@@ -449,15 +403,15 @@ const renderMarkdown = (markdown: string) => {
 
         <!-- “正在思考…” 提示：仅在没有可显示的 ThinkBlock 时出现 -->
         <div
-          v-if="(message as any).isThinking && !showThink"
+          v-if="((message as any).isThinking || isAwaitingFirstContent) && !showThink"
           class="flex items-center space-x-3 py-3"
         >
           <div class="flex space-x-1 items-center">
-            <div class="w-2 h-2 bg-gray-400 rounded-full thinking-dot"></div>
-            <div class="w-2 h-2 bg-gray-400 rounded-full thinking-dot"></div>
-            <div class="w-2 h-2 bg-gray-400 rounded-full thinking-dot"></div>
+            <div class="w-2 h-2 bg-gray-300 rounded-full thinking-dot"></div>
+            <div class="w-2 h-2 bg-gray-300 rounded-full thinking-dot"></div>
+            <div class="w-2 h-2 bg-gray-300 rounded-full thinking-dot"></div>
           </div>
-          <span class="text-sm text-gray-500 italic">
+          <span class="text-sm text-gray-400 italic">
             {{ agentName || t("agent.chat.assistant") }} 正在思考...
           </span>
         </div>
@@ -496,12 +450,17 @@ const renderMarkdown = (markdown: string) => {
             <!-- 文本（保持原样式容器，只把插值改成 v-html） -->
             <div
               v-if="content.type === MESSAGE_TYPES.TEXT"
-              class="prose prose-sm max-w-none"
+              class="prose prose-sm max-w-none dark:prose-invert text-sm leading-6 prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-1 prose-headings:mt-4 prose-headings:mb-2 prose-blockquote:my-3 prose-hr:my-4 prose-a:underline prose-a:underline-offset-4 prose-a:text-blue-600 hover:prose-a:text-blue-500 dark:prose-a:text-blue-400 dark:hover:prose-a:text-blue-300"
             >
-              <div
-                class="text-gray-800 whitespace-pre-wrap markdown-content"
-                v-html="renderMarkdown(content.data.text)"
-              ></div>
+              <AgentMarkdown
+                class="markdown-content"
+                :source="content.data.text"
+                :streaming="
+                  (message as any).role === 'assistant' &&
+                  ((message as any).isStreaming || isStreaming) &&
+                  !(message as any).isThinking
+                "
+              />
               <span
                 v-if="
                   (message as any).role === 'assistant' &&
@@ -516,9 +475,9 @@ const renderMarkdown = (markdown: string) => {
             <!-- Markdown -->
             <div
               v-else-if="content.type === MESSAGE_TYPES.MARKDOWN"
-              class="prose prose-sm max-w-none"
+              class="prose prose-sm max-w-none dark:prose-invert text-sm leading-6 prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-1 prose-headings:mt-4 prose-headings:mb-2 prose-blockquote:my-3 prose-hr:my-4 prose-a:underline prose-a:underline-offset-4 prose-a:text-blue-600 hover:prose-a:text-blue-500 dark:prose-a:text-blue-400 dark:hover:prose-a:text-blue-300"
             >
-              <div class="bg-gray-50 rounded-lg p-4 border">
+              <div class="bg-gray-50 dark:bg-white/5 rounded-lg p-4 border border-gray-200 dark:border-white/10">
                 <div class="flex items-center justify-between mb-2">
                   <span class="text-xs font-medium text-gray-600 uppercase"
                     >Markdown</span
@@ -531,7 +490,7 @@ const renderMarkdown = (markdown: string) => {
                   />
                 </div>
                 <div class="markdown-content">
-                  <div v-html="renderMarkdown(content.data.markdown)"></div>
+                  <AgentMarkdown class="markdown-content" :source="content.data.markdown" />
                 </div>
               </div>
             </div>
@@ -779,6 +738,14 @@ const renderMarkdown = (markdown: string) => {
           class="flex items-center space-x-2 mt-3 opacity-0 group-hover:opacity-100 transition-opacity"
         >
           <UButton
+            v-if="canRegenerateFromThisUserMessage"
+            size="xs"
+            variant="ghost"
+            icon="i-heroicons-pencil-square"
+            @click="emit('regenerate', (message as any).id)"
+            >重新编辑</UButton
+          >
+          <UButton
             v-if="message.role === 'assistant'"
             size="xs"
             variant="ghost"
@@ -818,50 +785,46 @@ const renderMarkdown = (markdown: string) => {
   opacity: 1;
 }
 
-.markdown-content {
-  color: #1f2937;
+/* 统一 MDC/Prose 的间距与分割线（避免“字太大、段落太松、横线太粗”） */
+:deep(.prose hr) {
+  border-color: rgba(255, 255, 255, 0.12);
+  margin: 1rem 0;
 }
-.markdown-content h1,
-.markdown-content h2,
-.markdown-content h3,
-.markdown-content h4,
-.markdown-content h5,
-.markdown-content h6 {
-  font-weight: 600;
-  color: #111827;
-  margin-top: 1rem;
-  margin-bottom: 0.5rem;
+:global(html:not(.dark)) :deep(.prose hr) {
+  border-color: rgba(17, 24, 39, 0.14);
 }
-.markdown-content p {
-  margin-bottom: 0.75rem;
+
+/* 链接必须“看起来像链接”：下划线 + 颜色 + hover */
+:deep(.prose a) {
+  cursor: pointer;
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  text-decoration-color: rgba(96, 165, 250, 0.55); /* blue-400 */
+  color: rgb(96, 165, 250);
 }
-.markdown-content ul,
-.markdown-content ol {
-  margin-left: 1rem;
-  margin-bottom: 0.75rem;
+:deep(.prose a:hover) {
+  text-decoration-color: rgba(96, 165, 250, 0.85);
+  color: rgb(147, 197, 253); /* blue-300 */
 }
-.markdown-content li {
-  margin-bottom: 0.25rem;
+:global(html:not(.dark)) :deep(.prose a) {
+  text-decoration-color: rgba(37, 99, 235, 0.35); /* blue-600 */
+  color: rgb(37, 99, 235);
 }
-.markdown-content code {
-  background-color: #f3f4f6;
-  color: #1f2937;
-  padding: 0.125rem 0.25rem;
-  border-radius: 0.25rem;
-  font-size: 0.875rem;
-  font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+:global(html:not(.dark)) :deep(.prose a:hover) {
+  text-decoration-color: rgba(37, 99, 235, 0.6);
+  color: rgb(29, 78, 216); /* blue-700 */
 }
-.markdown-content pre {
-  background-color: #f3f4f6;
-  padding: 0.75rem;
-  border-radius: 0.5rem;
-  overflow-x: auto;
-}
-.markdown-content blockquote {
-  border-left: 4px solid #d1d5db;
-  padding-left: 1rem;
-  font-style: italic;
-  color: #4b5563;
+
+/* 即便将来又开启了 heading anchor，也不要让标题看起来像链接 */
+:deep(.prose h1 a),
+:deep(.prose h2 a),
+:deep(.prose h3 a),
+:deep(.prose h4 a),
+:deep(.prose h5 a),
+:deep(.prose h6 a) {
+  text-decoration: none;
+  color: inherit;
 }
 
 /* 思考动画 */

--- a/web-admin/app/components/common/PromptModal.vue
+++ b/web-admin/app/components/common/PromptModal.vue
@@ -6,25 +6,58 @@ const props = defineProps<{
   defaultValue?: string
   confirmLabel?: string
   cancelLabel?: string
+  multiline?: boolean
+  rows?: number
 }>()
 
 const emit = defineEmits<{ close: [string | null] }>()
 const value = ref(props.defaultValue || '')
 const onDismiss = () => emit('close', null)
 const onConfirm = () => emit('close', value.value || '')
+
+const safeDescription = computed(() => {
+  const d = props.description ?? ''
+  return typeof d === 'string' ? d.replace(/\n+/g, ' ').trim() : ''
+})
+
+const resolvedRows = computed(() => {
+  const r = Number(props.rows || 0)
+  return r > 0 ? r : 3
+})
 </script>
 
 <template>
-  <UModal :title="props.title || '请输入'" :description="props.description" :close="{ onClick: onDismiss }">
+  <UModal :title="props.title || '请输入'" :description="safeDescription || '请输入内容'" :close="{ onClick: onDismiss }">
     <template #content>
-      <div class="space-y-3">
-        <UInput v-model="value" :placeholder="props.placeholder || '输入内容…'" />
-        <div class="flex justify-end gap-2 pt-1">
-          <UButton color="neutral" variant="subtle" @click="onDismiss">{{ props.cancelLabel || '取消' }}</UButton>
-          <UButton color="primary" @click="onConfirm">{{ props.confirmLabel || '确定' }}</UButton>
+      <UCard :ui="{ body: { padding: 'p-4 sm:p-5' }, footer: { padding: 'p-3 sm:p-4' } }">
+        <div class="space-y-3">
+          <UTextarea
+            v-if="props.multiline"
+            v-model="value"
+            :rows="resolvedRows"
+            :placeholder="props.placeholder || '输入内容…'"
+            class="w-full"
+          />
+          <UInput
+            v-else
+            v-model="value"
+            :placeholder="props.placeholder || '输入内容…'"
+            class="w-full"
+            autofocus
+            @keyup.enter="onConfirm"
+          />
+          <div class="text-xs text-[var(--text-tertiary)]">
+            {{ props.multiline ? '支持换行编辑；确认后将触发重新生成。' : '按回车可直接确认。' }}
+          </div>
         </div>
-      </div>
+
+        <template #footer>
+          <div class="flex justify-end gap-2">
+            <UButton color="neutral" variant="outline" @click="onDismiss">{{ props.cancelLabel || '取消' }}</UButton>
+            <UButton color="primary" @click="onConfirm">{{ props.confirmLabel || '确定' }}</UButton>
+          </div>
+        </template>
+      </UCard>
     </template>
   </UModal>
 </template>
-

--- a/web-admin/app/components/prose/ProseA.vue
+++ b/web-admin/app/components/prose/ProseA.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+  href?: string;
+  target?: string;
+}>();
+
+const href = computed(() => String(props.href || ""));
+const isExternal = computed(() => /^https?:\/\//i.test(href.value) || href.value.startsWith("//"));
+const isHash = computed(() => href.value.startsWith("#"));
+</script>
+
+<template>
+  <!-- 外链：新开标签页 -->
+  <a
+    v-if="isExternal"
+    :href="href"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <slot />
+  </a>
+
+  <!-- 页内锚点：默认行为 -->
+  <a v-else-if="isHash" :href="href">
+    <slot />
+  </a>
+
+  <!-- 站内路由：用 NuxtLink -->
+  <NuxtLink v-else :href="href" :target="props.target">
+    <slot />
+  </NuxtLink>
+</template>
+

--- a/web-admin/app/components/prose/ProsePre.vue
+++ b/web-admin/app/components/prose/ProsePre.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+const props = defineProps<{
+  code?: string;
+  language?: string | null;
+  filename?: string | null;
+  highlights?: unknown[];
+  meta?: string | null;
+  class?: string | null;
+}>();
+
+const copied = ref(false);
+
+const label = computed(() => {
+  if (props.filename) return String(props.filename);
+  if (props.language) return String(props.language).toUpperCase();
+  return "CODE";
+});
+
+const onCopy = async () => {
+  const text = String(props.code ?? "");
+  if (!text) return;
+  try {
+    await navigator.clipboard.writeText(text);
+    copied.value = true;
+    setTimeout(() => (copied.value = false), 1200);
+  } catch {}
+};
+</script>
+
+<template>
+  <div class="px-codeblock">
+    <div class="px-codeblock__header">
+      <span class="px-codeblock__lang">{{ label }}</span>
+      <button type="button" class="px-codeblock__copy" @click="onCopy">
+        {{ copied ? "已复制" : "复制" }}
+      </button>
+    </div>
+    <pre :class="['px-codeblock__pre', props.class]"><slot /></pre>
+  </div>
+</template>
+
+<style scoped>
+.px-codeblock {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #0b1220;
+  margin: 0.75rem 0;
+}
+.px-codeblock__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.px-codeblock__lang {
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  color: rgba(229, 231, 235, 0.9);
+}
+.px-codeblock__copy {
+  font-size: 0.75rem;
+  color: rgba(229, 231, 235, 0.9);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+}
+.px-codeblock__copy:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+.px-codeblock__pre {
+  margin: 0;
+  padding: 0.75rem;
+  overflow-x: auto;
+  background: transparent;
+}
+.px-codeblock__pre :deep(code) {
+  display: block;
+  white-space: pre;
+  color: #e5e7eb;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  background: transparent;
+  padding: 0;
+}
+
+/* Light mode：保持 ChatGPT 一样代码块仍然深色，但边框更柔和 */
+:global(html:not(.dark)) .px-codeblock {
+  border-color: rgba(17, 24, 39, 0.12);
+}
+</style>
+

--- a/web-admin/app/components/settings/ai/ModalityParamsForm.vue
+++ b/web-admin/app/components/settings/ai/ModalityParamsForm.vue
@@ -335,6 +335,32 @@
       </div>
     </div>
 
+    <!-- 3D 生成参数 -->
+    <div v-else-if="activeModality === 'model3d'" class="space-y-4">
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <label
+            class="block text-sm font-medium text-[var(--text-primary)] mb-2"
+          >
+            输出格式
+          </label>
+          <USelect
+            v-model="model3d.outputFormat"
+            :options="model3dFormatOptions"
+            placeholder="选择格式"
+          />
+        </div>
+        <div>
+          <label
+            class="block text-sm font-medium text-[var(--text-primary)] mb-2"
+          >
+            提示词增强
+          </label>
+          <UInput v-model="model3d.promptHint" placeholder="可选的提示词前缀" />
+        </div>
+      </div>
+    </div>
+
     <!-- 重排序参数 -->
     <div v-else-if="activeModality === 'rerank'" class="space-y-4">
       <div class="grid grid-cols-2 gap-4">
@@ -384,6 +410,7 @@ type Modality =
   | "audio_tts"
   | "audio_asr"
   | "video"
+  | "model3d"
   | "rerank";
 
 interface Props {
@@ -394,12 +421,14 @@ interface Props {
   audioTts: any;
   audioAsr: any;
   video: any;
+  model3d: any;
   rerank: any;
   imageSizeOptions: string[];
   imageQualityOptions: string[];
   imageFormatOptions: string[];
   truncateOptions: string[];
   videoResolutionOptions: string[];
+  model3dFormatOptions: string[];
   voiceOptions: string[];
   audioFormatOptions: string[];
   audioQualityOptions: string[];

--- a/web-admin/app/components/settings/ai/ProviderModelForm.vue
+++ b/web-admin/app/components/settings/ai/ProviderModelForm.vue
@@ -1,5 +1,17 @@
 <template>
   <UForm :state="state" class="space-y-4">
+    <div v-if="authModeOptions.length" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-sm mb-1 text-[var(--text-secondary)]">接入方式</label>
+        <USelect
+          v-model="state.authMode"
+          :items="authModeOptions"
+          icon="i-heroicons-adjustments-horizontal"
+          class="w-full"
+          placeholder="选择接入方式"
+        />
+      </div>
+    </div>
     <!-- Provider 与 Model 行 -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
@@ -12,6 +24,7 @@
           :disabled="!providerOptions?.length"
           :loading="!providerOptions?.length"
           icon="i-heroicons-building-library"
+          class="w-full"
           :placeholder="$t('agent.config.selectProvider')"
           @update:model-value="emit('providerChanged', $event)"
         />
@@ -25,6 +38,7 @@
           :items="modelOptions"
           :disabled="!modelOptions?.length"
           icon="i-heroicons-cpu-chip"
+          class="w-full"
           :placeholder="$t('agent.config.selectModel')"
           :loading="!modelOptions?.length"
         />
@@ -66,12 +80,16 @@ const props = withDefaults(
       auth?: {
         scheme: string;
         fields: string[];
+        defaults?: Record<string, string>;
       };
     } | null;
     state: {
       provider: string;
       model: string;
+      authMode?: string;
       apiKey: string;
+      secretId?: string;
+      secretKey?: string;
       baseURL: string;
       region: string;
       organization: string;
@@ -91,8 +109,144 @@ const emit = defineEmits<{
 
 const isAzure = computed(() => props.state.provider === "Azure OpenAI");
 
+const authModeOptions = computed(() => {
+  const modes = props.activeProvider?.auth?.modes ?? [];
+  if (!Array.isArray(modes) || modes.length === 0) return [];
+  return modes.map((m) => ({
+    label: m.label || m.id,
+    value: m.id,
+  }));
+});
+
+const selectedAuthMode = computed(() => {
+  const modes = props.activeProvider?.auth?.modes ?? [];
+  if (!Array.isArray(modes) || modes.length === 0) return null;
+  const selected = String(props.state.authMode || "").trim().toLowerCase();
+  return (
+    modes.find((m) => String(m.id || "").trim().toLowerCase() === selected) ||
+    modes[0] ||
+    null
+  );
+});
+
+watch(
+  authModeOptions,
+  (opts) => {
+    if (!Array.isArray(opts) || opts.length === 0) return;
+    if (!String(props.state.authMode || "").trim()) {
+      props.state.authMode = String(opts[0].value || "");
+    }
+  },
+  { immediate: true }
+);
+
+watch(
+  selectedAuthMode,
+  (next) => {
+    if (!next?.defaults) return;
+    // 仅在字段为空时用默认值回填，避免覆盖用户输入
+    const defBaseURL = String(next.defaults.base_url || "").trim();
+    if (defBaseURL && !String(props.state.baseURL || "").trim()) {
+      props.state.baseURL = defBaseURL;
+    }
+    const defRegion = String(next.defaults.region || "").trim();
+    if (defRegion && !String(props.state.region || "").trim()) {
+      props.state.region = defRegion;
+    }
+  },
+  { immediate: true }
+);
+
+// 字段映射
+const fieldMap: Record<
+  string,
+  { label: string; type: string; placeholder: string; required: boolean }
+> = {
+  api_key: {
+    label: "API Key",
+    type: "password",
+    placeholder: "••••••••",
+    required: true,
+  },
+  base_url: {
+    label: "Base URL",
+    type: "text",
+    placeholder: "https://api.example.com",
+    required: false,
+  },
+  organization: {
+    label: "Organization / Project（可选）",
+    type: "text",
+    placeholder: "组织或订阅ID（可选）",
+    required: false,
+  },
+  region: {
+    label: "Region / Location",
+    type: "text",
+    placeholder: "如 ap-guangzhou / eastus",
+    required: false,
+  },
+  azure_deployment: {
+    label: "Azure Deployment（可选）",
+    type: "text",
+    placeholder: "Azure OpenAI 的部署名称",
+    required: false,
+  },
+  secret_id: {
+    label: "SecretId",
+    type: "text",
+    placeholder: "腾讯云 SecretId",
+    required: true,
+  },
+  secret_key: {
+    label: "SecretKey",
+    type: "password",
+    placeholder: "腾讯云 SecretKey",
+    required: true,
+  },
+};
+
 // 动态字段配置
 const authFields = computed(() => {
+  const modes = props.activeProvider?.auth?.modes ?? [];
+  if (Array.isArray(modes) && modes.length) {
+    const hit = selectedAuthMode.value;
+    const fields = hit?.fields ?? [];
+    return fields.map((field) => ({
+      key: field,
+      ...(() => {
+        const base =
+          fieldMap[field] ||
+          ({
+            label: field,
+            type: "text",
+            placeholder: "",
+            required: false,
+          } as const);
+        const defaults = hit?.defaults ?? {};
+        if (field === "base_url") {
+          const required =
+            base.required || !String((defaults as any).base_url || "").trim();
+          return {
+            ...base,
+            required,
+            label: required ? "Base URL" : "Base URL（可选）",
+          };
+        }
+        if (field === "region") {
+          const required =
+            base.required || !String((defaults as any).region || "").trim();
+          return {
+            ...base,
+            required,
+            label: required ? "Region / Location" : "Region / Location（可选）",
+          };
+        }
+        return base;
+      })(),
+    }));
+  }
+
   if (!props.activeProvider?.auth?.fields) {
     // 默认字段
     return [
@@ -113,51 +267,38 @@ const authFields = computed(() => {
     ];
   }
 
-  // 字段映射
-  const fieldMap: Record<
-    string,
-    { label: string; type: string; placeholder: string; required: boolean }
-  > = {
-    api_key: {
-      label: "API Key",
-      type: "password",
-      placeholder: "••••••••",
-      required: true,
-    },
-    base_url: {
-      label: "Base URL（可选）",
-      type: "text",
-      placeholder: "https://api.example.com",
-      required: false,
-    },
-    organization: {
-      label: "Organization / Project（可选）",
-      type: "text",
-      placeholder: "组织或订阅ID（可选）",
-      required: false,
-    },
-    region: {
-      label: "Region / Location（可选）",
-      type: "text",
-      placeholder: "如 eastus / us-east-1",
-      required: false,
-    },
-    azure_deployment: {
-      label: "Azure Deployment（可选）",
-      type: "text",
-      placeholder: "Azure OpenAI 的部署名称",
-      required: false,
-    },
-  };
-
   return props.activeProvider.auth.fields.map((field) => ({
     key: field,
-    ...(fieldMap[field] || {
-      label: field,
-      type: "text",
-      placeholder: "",
-      required: false,
-    }),
+    ...(() => {
+      const base =
+        fieldMap[field] ||
+        ({
+          label: field,
+          type: "text",
+          placeholder: "",
+          required: false,
+        } as const);
+      const defaults = props.activeProvider?.auth?.defaults ?? {};
+      if (field === "base_url") {
+        const required =
+          base.required || !String((defaults as any).base_url || "").trim();
+        return {
+          ...base,
+          required,
+          label: required ? "Base URL" : "Base URL（可选）",
+        };
+      }
+      if (field === "region") {
+        const required =
+          base.required || !String((defaults as any).region || "").trim();
+        return {
+          ...base,
+          required,
+          label: required ? "Region / Location" : "Region / Location（可选）",
+        };
+      }
+      return base;
+    })(),
   }));
 });
 
@@ -169,6 +310,8 @@ const getStateKey = (backendKey: string) => {
     organization: "organization",
     region: "region",
     azure_deployment: "azureDeployment",
+    secret_id: "secretId",
+    secret_key: "secretKey",
   };
   return keyMap[backendKey] || backendKey;
 };

--- a/web-admin/app/composables/agent/useAgentManager.ts
+++ b/web-admin/app/composables/agent/useAgentManager.ts
@@ -12,6 +12,7 @@ export interface AgentConfig {
   name: string;
   description: string;
   avatar?: string;
+  provider?: string;
   model: string;
   systemPrompt: string;
   temperature: number;
@@ -20,6 +21,7 @@ export interface AgentConfig {
   frequencyPenalty: number;
   presencePenalty: number;
   isActive: boolean;
+  useSystemModelConfig?: boolean;
   capabilities: Array<{
     name: string;
     description: string;

--- a/web-admin/app/composables/agent/useChatSessions.ts
+++ b/web-admin/app/composables/agent/useChatSessions.ts
@@ -81,6 +81,26 @@ export function useChatSessions(opts: { pageSize?: number } = {}) {
   const messageStore = useMessageStore();
   const { t } = useI18n();
 
+  const LAST_AGENT_ID_KEY = "powerx.agent.lastSelectedAgentId";
+  const readLastAgentId = (): number | null => {
+    if (typeof window === "undefined") return null;
+    try {
+      const v = localStorage.getItem(LAST_AGENT_ID_KEY);
+      if (!v) return null;
+      const n = Number(v);
+      return Number.isFinite(n) && n > 0 ? n : null;
+    } catch {
+      return null;
+    }
+  };
+  const writeLastAgentId = (agentId: number | null) => {
+    if (typeof window === "undefined") return;
+    try {
+      if (!agentId) localStorage.removeItem(LAST_AGENT_ID_KEY);
+      else localStorage.setItem(LAST_AGENT_ID_KEY, String(agentId));
+    } catch {}
+  };
+
   /**
    * 将后端数据转换为前端格式
    */
@@ -221,6 +241,7 @@ export function useChatSessions(opts: { pageSize?: number } = {}) {
       if (response) {
         const newSession = mapSessionDTO(response);
         sessionStore.addSession(agentId, newSession);
+        writeLastAgentId(agentId);
         return newSession;
       }
       throw new Error(t("agent.chat.errors.createSessionFailedNoData"));
@@ -242,6 +263,8 @@ export function useChatSessions(opts: { pageSize?: number } = {}) {
         params: {
           env: "dev",
         },
+        timeout: 60000,
+        useGlobalLoading: false,
       });
 
       sessionStore.removeSession(agentId, sessionId);
@@ -420,8 +443,15 @@ export function useChatSessions(opts: { pageSize?: number } = {}) {
     loadMoreMessages,
 
     // Store 方法的直接暴露
-    selectSession: sessionStore.selectSession,
-    selectAgent: sessionStore.selectAgent,
+    selectSession: (agentId: number, sessionId: number | string) => {
+      sessionStore.selectSession(agentId, sessionId);
+      writeLastAgentId(agentId);
+    },
+    selectAgent: (agentId: number) => {
+      sessionStore.selectAgent(agentId);
+      writeLastAgentId(agentId);
+    },
+    getLastSelectedAgentId: readLastAgentId,
     clearError: sessionStore.clearError,
     clear: sessionStore.clear,
   };

--- a/web-admin/app/composables/agent/useDualChannelConnection.ts
+++ b/web-admin/app/composables/agent/useDualChannelConnection.ts
@@ -4,6 +4,8 @@ import {
   computed,
   watchEffect,
   watch,
+  onMounted,
+  onUnmounted,
   type Ref,
   type ComputedRef,
 } from "vue";
@@ -23,6 +25,11 @@ export interface DualChannelConnection {
     message: string,
     flowId?: string,
     meta?: Record<string, any>
+  ) => Promise<void>;
+  regenerateFrom: (
+    messageId: number,
+    flowId?: string,
+    editedMessage?: string
   ) => Promise<void>;
   sendCommand: (command: any) => boolean;
   messages: Ref<any[]>;
@@ -48,6 +55,7 @@ export function useDualChannelConnection(
   const messageStore = useMessageStore();
 
   let pendingAssistantId: string | null = null;
+  let currentSseAbort: AbortController | null = null;
 
   watch(sessionId, (newSessionId, oldSessionId) => {
     if (oldSessionId && messages.value.length > 0) {
@@ -232,6 +240,14 @@ export function useDualChannelConnection(
     flowId = BaseFlowKey,
     meta?: Record<string, any>
   ) => {
+    // 避免旧请求残留导致一直“生成中”
+    try {
+      currentSseAbort?.abort();
+    } catch {}
+
+    const abortController = new AbortController();
+    currentSseAbort = abortController;
+
     const requestId = `req_${Date.now()}_${Math.random()
       .toString(36)
       .slice(2, 9)}`;
@@ -244,7 +260,16 @@ export function useDualChannelConnection(
     };
     if (agentId?.value) params.agent_id = agentId.value;
     if (sessionId?.value) params.session_id = sessionId.value;
-    if (meta) Object.assign(params, meta);
+    if (meta) {
+      // 兼容前端历史字段：sessionId/agentId -> session_id/agent_id
+      if ((meta as any).session_id == null && (meta as any).sessionId != null) {
+        (meta as any).session_id = (meta as any).sessionId;
+      }
+      if ((meta as any).agent_id == null && (meta as any).agentId != null) {
+        (meta as any).agent_id = (meta as any).agentId;
+      }
+      Object.assign(params, meta);
+    }
 
     // 你现在用 mock 流
     // const url = buildHttpUrl("/agents/stream/mock", params);
@@ -258,6 +283,7 @@ export function useDualChannelConnection(
           "Cache-Control": "no-cache",
           Authorization: `${getTokenType()} ${getAuthToken()}`,
         },
+        signal: abortController.signal,
       });
       if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
 
@@ -266,9 +292,12 @@ export function useDualChannelConnection(
       const decoder = new TextDecoder();
 
       const run = async () => {
-        let currentEvent: string | null = null;
+        // SSE 是“以空行分隔事件块”的协议；网络分片可能把一行 JSON 拆开，
+        // 不能用 chunk.split("\n") 逐行即时 JSON.parse，否则会丢事件导致“前端无反馈”。
+        let sseBuffer = "";
         let hasReceivedData = false;
         let timeoutId: any = null;
+        let abortedByClient = false;
 
         // 只创建一次解析器
         const thinkParser = useStreamingThinkParser();
@@ -280,6 +309,36 @@ export function useDualChannelConnection(
             (m) => m.id === pendingAssistantId
           );
           return { idx, msg: idx >= 0 ? messages.value[idx] : null };
+        };
+
+        const finalize = (opts?: {
+          errorMessage?: string;
+          abort?: boolean;
+        }) => {
+          const { idx, msg } = getPendingAssistant();
+          if (idx >= 0 && msg) {
+            msg.done = true;
+            msg.isStreaming = false;
+            msg.isThinking = false;
+            if (opts?.errorMessage) {
+              msg.isError = true;
+              msg.content = opts.errorMessage;
+            }
+            bumpMessagesRef();
+          }
+
+          currentRequestId.value = null;
+          pendingAssistantId = null;
+          if (currentSseAbort === abortController) {
+            currentSseAbort = null;
+          }
+
+          if (opts?.abort) {
+            abortedByClient = true;
+            try {
+              abortController.abort();
+            } catch {}
+          }
         };
 
         const connectionTimeout = () => {
@@ -304,195 +363,246 @@ export function useDualChannelConnection(
               });
               bumpMessagesRef();
             }
-            currentRequestId.value = null;
+            finalize({ abort: true });
           }
         };
         timeoutId = setTimeout(connectionTimeout, 10000);
 
+        const dispatchSSEBlock = (block: string) => {
+          // 解析单个 SSE block（以空行分隔）
+          let eventName = "";
+          const dataLines: string[] = [];
+          for (const line of block.split("\n")) {
+            if (!line) continue;
+            if (line.startsWith(":")) continue; // comment/keepalive
+            if (line.startsWith("event:")) {
+              eventName = line.slice(6).trim();
+              continue;
+            }
+            if (line.startsWith("data:")) {
+              dataLines.push(line.slice(5).trimStart());
+              continue;
+            }
+          }
+
+          const raw = dataLines.join("\n").trim();
+          if (raw === "[DONE]") {
+            finalize({ abort: true });
+            return;
+          }
+
+          // 只要收到任何 block，都算“服务器已响应”，停止“确认包超时”计时
+          if (!hasReceivedData) {
+            hasReceivedData = true;
+            if (timeoutId) {
+              clearTimeout(timeoutId);
+              timeoutId = null;
+            }
+          }
+
+          // 允许没有 data 的事件（例如纯心跳/控制帧）
+          let payload: any = {};
+          if (raw) {
+            try {
+              payload = JSON.parse(raw);
+            } catch {
+              payload = { raw };
+            }
+          }
+          if (!payload.type && eventName) payload.type = eventName;
+
+          onMessageCallback?.(payload);
+          const type = String(payload.type || eventName || "").toLowerCase();
+
+          // meta：用于把“前端临时消息 id”映射到“DB message id”（支持立即重新生成）
+          if (type === SSE_EVENT_TYPES.META) {
+            const clientMsgId =
+              payload?.client_msg_id ?? payload?.data?.client_msg_id;
+            const userMessageId =
+              payload?.user_message_id ?? payload?.data?.user_message_id;
+            if (clientMsgId && userMessageId) {
+              const idx = messages.value.findIndex((m) => m.id === clientMsgId);
+              if (idx >= 0) {
+                messages.value[idx] = { ...messages.value[idx], id: userMessageId };
+                bumpMessagesRef();
+              }
+            }
+            return;
+          }
+
+          // 控制事件略过
+          if (
+            type === SSE_EVENT_TYPES.ACK ||
+            type === SSE_EVENT_TYPES.START ||
+            type === SSE_EVENT_TYPES.INTENT ||
+            type === SSE_EVENT_TYPES.PLAN ||
+            type === SSE_EVENT_TYPES.HEARTBEAT ||
+            type === SSE_EVENT_TYPES.ACTION
+          ) {
+            return;
+          }
+
+          // 内容事件
+          if (
+            type === SSE_EVENT_TYPES.TOKEN ||
+            type === SSE_EVENT_TYPES.CHUNK ||
+            type === SSE_EVENT_TYPES.DATA ||
+            type === SSE_EVENT_TYPES.FINAL
+          ) {
+            // 后端会先发一个 EventData（step_id=start, data.message=start）作为“流开始”占位；
+            // 这条不应触发 UI 创建空的 assistant 气泡，否则会出现“空白回复 + 没有思考提示”。
+            if (
+              type === SSE_EVENT_TYPES.DATA &&
+              (String(payload?.step_id || "") === "start" ||
+                String(payload?.data?.message || "") === "start")
+            ) {
+              return;
+            }
+
+            // 1) 找到/创建唯一的 assistant 占位
+            const idx = messages.value.findIndex((m) => m.id === pendingAssistantId);
+            if (idx < 0) {
+              pendingAssistantId = `a_${Date.now()}`;
+              messages.value.push({
+                id: pendingAssistantId,
+                role: "assistant",
+                content: "",
+                timestamp: Date.now(),
+                isStreaming: true,
+                done: false,
+                isThinking: true,
+                isError: false,
+                meta: {
+                  think: {
+                    blocks: [],
+                    current: "",
+                    hasActiveThink: false,
+                    hasThink: false,
+                  },
+                },
+              });
+            }
+            const answerIdx = messages.value.findIndex(
+              (m) => m.id === pendingAssistantId
+            );
+            const answer = messages.value[answerIdx];
+
+            // 2) 取本次文本片段
+            const piece = pickText(payload, type) || "";
+
+            // 3) 关键：DATA/FINAL = snapshot（覆盖），TOKEN/CHUNK = delta（追加）
+            const mode =
+              type === SSE_EVENT_TYPES.DATA || type === SSE_EVENT_TYPES.FINAL
+                ? "snapshot"
+                : "delta";
+
+            const {
+              completedThinks,
+              currentThinkContent,
+              mainContent,
+              hasActiveThink,
+              hasThink,
+            } = thinkParser.parseStreamingContent(piece, mode);
+
+            // 4) 覆盖正文（不要 +=）
+            answer.content = mainContent; // 覆盖！不要改成 +=
+
+            // 5) 更新状态 & Think 元数据
+            answer.isStreaming = type !== SSE_EVENT_TYPES.FINAL;
+            answer.done = type === SSE_EVENT_TYPES.FINAL;
+            answer.isThinking = hasActiveThink;
+            answer.meta = {
+              ...(answer.meta || {}),
+              think: {
+                blocks: completedThinks,
+                current: currentThinkContent,
+                hasActiveThink,
+                hasThink:
+                  hasThink ||
+                  completedThinks.length > 0 ||
+                  !!currentThinkContent,
+              },
+            };
+
+            // 6) FINAL 收尾
+            if (type === SSE_EVENT_TYPES.FINAL) {
+              // 后端可能不会发送 [DONE]/END，FINAL 视为一次响应结束
+              finalize({ abort: true });
+              return;
+            }
+
+            bumpMessagesRef();
+            return;
+          }
+
+          if (type === SSE_EVENT_TYPES.END) {
+            finalize({ abort: true });
+            return;
+          }
+
+          if (type === SSE_EVENT_TYPES.ERROR) {
+            const { idx, msg } = getPendingAssistant();
+            if (idx >= 0 && msg) {
+              msg.isThinking = false;
+              msg.isStreaming = false;
+              msg.isError = true;
+              msg.content =
+                payload?.message ||
+                payload?.error ||
+                "发生错误：未知的服务端错误。";
+              bumpMessagesRef();
+            } else {
+              messages.value.push({
+                id: `error_${Date.now()}`,
+                role: "assistant",
+                content:
+                  payload?.message ||
+                  payload?.error ||
+                  "发生错误：未知的服务端错误。",
+                timestamp: Date.now(),
+                isError: true,
+              });
+              bumpMessagesRef();
+            }
+            finalize({ abort: true });
+            return;
+          }
+        };
+
         try {
           while (true) {
             const { done, value } = await reader.read();
-            if (done) break;
-            const chunk = decoder.decode(value, { stream: true });
-
-            for (const line of chunk.split(/\r?\n/)) {
-              if (!line) continue;
-
-              if (line.startsWith("event:")) {
-                currentEvent = line.slice(6).trim();
-                continue;
+            if (done) {
+              // flush 残留：有些实现可能在断开前未补齐空行分隔
+              if (sseBuffer.trim()) {
+                dispatchSSEBlock(sseBuffer);
+                sseBuffer = "";
               }
-              if (!line.startsWith("data:")) continue;
+              // 连接正常结束但未显式发送 [DONE]/END/FINAL：也要收尾，避免 UI 永久“生成中”
+              finalize();
+              break;
+            }
+            const chunk = decoder.decode(value, { stream: true })
+              .replace(/\r\n/g, "\n")
+              .replace(/\r/g, "\n");
+            sseBuffer += chunk;
 
-              const raw = line.slice(5).trim();
-              if (raw === "[DONE]") {
-                currentRequestId.value = null;
-                continue;
-              }
-
-              let payload: any;
-              try {
-                payload = JSON.parse(raw);
-              } catch {
-                payload = { raw };
-              }
-              if (!payload.type && currentEvent) payload.type = currentEvent;
-
-              if (!hasReceivedData) {
-                hasReceivedData = true;
-                if (timeoutId) {
-                  clearTimeout(timeoutId);
-                  timeoutId = null;
-                }
-              }
-
-              onMessageCallback?.(payload);
-              const type = String(
-                payload.type || currentEvent || ""
-              ).toLowerCase();
-
-              // 控制事件略过
-              if (
-                type === SSE_EVENT_TYPES.ACK ||
-                type === SSE_EVENT_TYPES.START ||
-                type === SSE_EVENT_TYPES.INTENT ||
-                type === SSE_EVENT_TYPES.PLAN ||
-                type === SSE_EVENT_TYPES.META ||
-                type === SSE_EVENT_TYPES.HEARTBEAT ||
-                type === SSE_EVENT_TYPES.ACTION
-              ) {
-                continue;
-              }
-
-              // 内容事件
-              if (
-                type === SSE_EVENT_TYPES.TOKEN ||
-                type === SSE_EVENT_TYPES.CHUNK ||
-                type === SSE_EVENT_TYPES.DATA ||
-                type === SSE_EVENT_TYPES.FINAL
-              ) {
-                // 1) 找到/创建唯一的 assistant 占位
-                const idx = messages.value.findIndex(
-                  (m) => m.id === pendingAssistantId
-                );
-                if (idx < 0) {
-                  pendingAssistantId = `a_${Date.now()}`;
-                  messages.value.push({
-                    id: pendingAssistantId,
-                    role: "assistant",
-                    content: "",
-                    timestamp: Date.now(),
-                    isStreaming: true,
-                    done: false,
-                    isThinking: true,
-                    isError: false,
-                    meta: {
-                      think: {
-                        blocks: [],
-                        current: "",
-                        hasActiveThink: false,
-                        hasThink: false,
-                      },
-                    },
-                  });
-                }
-                const answerIdx = messages.value.findIndex(
-                  (m) => m.id === pendingAssistantId
-                );
-                const answer = messages.value[answerIdx];
-
-                // 2) 取本次文本片段
-                const piece = pickText(payload, type) || "";
-
-                // 3) 关键：DATA/FINAL = snapshot（覆盖），TOKEN/CHUNK = delta（追加）
-                const mode =
-                  type === SSE_EVENT_TYPES.DATA ||
-                  type === SSE_EVENT_TYPES.FINAL
-                    ? "snapshot"
-                    : "delta";
-
-                // ⚠️ 注意：thinkParser 要在 while 循环外提前 const thinkParser = useStreamingThinkParser();
-                const {
-                  completedThinks,
-                  currentThinkContent,
-                  mainContent,
-                  hasActiveThink,
-                  hasThink,
-                } = thinkParser.parseStreamingContent(piece, mode);
-
-                // 4) 覆盖正文（不要 +=）
-                answer.content = mainContent; // 覆盖！不要改成 +=
-
-                // 5) 更新状态 & Think 元数据
-                answer.isStreaming = type !== SSE_EVENT_TYPES.FINAL;
-                answer.done = type === SSE_EVENT_TYPES.FINAL;
-                answer.isThinking = hasActiveThink;
-                answer.meta = {
-                  ...(answer.meta || {}),
-                  think: {
-                    blocks: completedThinks,
-                    current: currentThinkContent,
-                    hasActiveThink,
-                    hasThink:
-                      hasThink ||
-                      completedThinks.length > 0 ||
-                      !!currentThinkContent,
-                  },
-                };
-
-                // 6) FINAL 收尾
-                if (type === SSE_EVENT_TYPES.FINAL) {
-                  pendingAssistantId = null;
-                }
-
-                bumpMessagesRef();
-                continue;
-              }
-
-              if (type === SSE_EVENT_TYPES.END) {
-                const { idx, msg } = getPendingAssistant();
-                if (idx >= 0 && msg) {
-                  msg.done = true;
-                  msg.isStreaming = false;
-                  msg.isThinking = false;
-                  bumpMessagesRef();
-                }
-                currentRequestId.value = null;
-                pendingAssistantId = null;
-                continue;
-              }
-
-              if (type === SSE_EVENT_TYPES.ERROR) {
-                const { idx, msg } = getPendingAssistant();
-                if (idx >= 0 && msg) {
-                  msg.isThinking = false;
-                  msg.isStreaming = false;
-                  msg.isError = true;
-                  msg.content =
-                    payload?.message ||
-                    payload?.error ||
-                    "发生错误：未知的服务端错误。";
-                  bumpMessagesRef();
-                } else {
-                  messages.value.push({
-                    id: `error_${Date.now()}`,
-                    role: "assistant",
-                    content:
-                      payload?.message ||
-                      payload?.error ||
-                      "发生错误：未知的服务端错误。",
-                    timestamp: Date.now(),
-                    isError: true,
-                  });
-                  bumpMessagesRef();
-                }
-                currentRequestId.value = null;
-                pendingAssistantId = null;
-                continue;
-              }
+            // SSE 事件块：以空行分隔（\n\n）
+            // 这里必须缓冲处理，避免网络分片导致 data 行被拆开而解析失败。
+            while (true) {
+              const sep = sseBuffer.indexOf("\n\n");
+              if (sep < 0) break;
+              const block = sseBuffer.slice(0, sep);
+              sseBuffer = sseBuffer.slice(sep + 2);
+              if (!block.trim()) continue;
+              dispatchSSEBlock(block);
             }
           }
         } catch (err) {
+          // 主动 abort 结束流：不算错误
+          if (abortedByClient && (err as any)?.name === "AbortError") {
+            return;
+          }
           const { idx, msg } = (() => {
             if (!pendingAssistantId) return { idx: -1, msg: null as any };
             const i = messages.value.findIndex(
@@ -575,12 +685,16 @@ export function useDualChannelConnection(
     flowId = BaseFlowKey,
     meta?: Record<string, any>
   ) => {
-    messages.value.push({
-      id: `u_${Date.now()}`,
-      role: "user",
-      content: message,
-      timestamp: Date.now(),
-    });
+    const noUserEcho = !!(meta as any)?.noUserEcho;
+    const clientMsgId = `u_${Date.now()}`;
+    if (!noUserEcho) {
+      messages.value.push({
+        id: clientMsgId,
+        role: "user",
+        content: message,
+        timestamp: Date.now(),
+      });
+    }
 
     pendingAssistantId = `thinking_${Date.now()}`;
     messages.value.push({
@@ -603,7 +717,61 @@ export function useDualChannelConnection(
     });
     bumpMessagesRef();
 
-    await sendSSEMessage(message, flowId, meta);
+    await sendSSEMessage(message, flowId, {
+      ...(meta || {}),
+      // 仅在本地生成的 user 消息需要映射
+      ...(noUserEcho ? {} : { client_msg_id: clientMsgId }),
+    });
+  };
+
+  const regenerateFrom = async (
+    messageId: number,
+    flowId = BaseFlowKey,
+    editedMessage?: string
+  ) => {
+    if (!messageId) return;
+
+    // 裁剪本地消息：保留到该 user message（含）为止
+    const cutoff = messages.value.findIndex((m) => m.id === messageId);
+    if (cutoff >= 0) {
+      if (typeof editedMessage === "string") {
+        const trimmed = editedMessage.trim();
+        if (trimmed) {
+          const m: any = messages.value[cutoff];
+          if (m?.role === "user") {
+            messages.value[cutoff] = { ...m, content: trimmed };
+          }
+        }
+      }
+      messages.value = messages.value.slice(0, cutoff + 1);
+    }
+
+    // 放一个新的 assistant 占位
+    pendingAssistantId = `thinking_${Date.now()}`;
+    messages.value.push({
+      id: pendingAssistantId,
+      role: "assistant",
+      content: "",
+      timestamp: Date.now(),
+      isThinking: true,
+      isStreaming: true,
+      done: false,
+      isError: false,
+      meta: {
+        think: {
+          blocks: [],
+          current: "",
+          hasActiveThink: false,
+          hasThink: false,
+        },
+      },
+    });
+    bumpMessagesRef();
+
+    await sendSSEMessage((editedMessage ?? "").trim(), flowId, {
+      noUserEcho: true,
+      regen_from_message_id: messageId,
+    });
   };
 
   const cancel = () => {
@@ -611,6 +779,10 @@ export function useDualChannelConnection(
       wsConnection?.close();
     } catch {}
     wsConnection = null;
+    try {
+      currentSseAbort?.abort();
+    } catch {}
+    currentSseAbort = null;
     currentRequestId.value = null;
   };
 
@@ -632,6 +804,7 @@ export function useDualChannelConnection(
     reconnectWS,
     cancel,
     sendMessage,
+    regenerateFrom,
     sendCommand,
     messages,
     isGenerating,
@@ -661,6 +834,40 @@ export function useDualChannelConnection(
         reconnectWS();
       }
     });
+
+    // 参考 ChatGPT 体验：仅在页面恢复活跃时重连；切换会话/离开页面再中断
+    const handleFocus = () => {
+      reconnectSSE();
+      reconnectWS();
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        reconnectSSE();
+        reconnectWS();
+      }
+    };
+
+    onMounted(() => {
+      window.addEventListener("focus", handleFocus);
+      document.addEventListener("visibilitychange", handleVisibility);
+      window.addEventListener("beforeunload", cancel);
+    });
+
+    onUnmounted(() => {
+      window.removeEventListener("focus", handleFocus);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("beforeunload", cancel);
+      cancel();
+    });
+
+    // 切换会话/智能体时：中断当前流，避免跨会话串流导致 UI 异常
+    watch(
+      [agentId ?? ref(null), sessionId ?? ref(null)],
+      ([newAgentId, newSessionId], [oldAgentId, oldSessionId]) => {
+        if (currentRequestId.value == null) return;
+        if (newAgentId !== oldAgentId || newSessionId !== oldSessionId) cancel();
+      }
+    );
   }
 
   return connection;

--- a/web-admin/app/composables/api/index.ts
+++ b/web-admin/app/composables/api/index.ts
@@ -238,6 +238,28 @@ const applyErrorInterceptors = async (error: any): Promise<any> => {
   if (!result || !result.response) {
     throw new Error("网络错误，请检查网络连接");
   }
+
+  // 统一把后端 ErrorResponse.error 显示出来，避免前端只看到 “400 Bad Request”
+  const data = (result && (result.data ?? result.response?._data ?? result.response?.data)) as any;
+  if (data) {
+    let msg = "";
+    if (typeof data === "string") {
+      msg = data;
+    } else if (typeof data === "object") {
+      msg =
+        (typeof data.error === "string" && data.error) ||
+        (typeof data.message === "string" && data.message) ||
+        (typeof data.detail === "string" && data.detail) ||
+        "";
+    }
+    msg = String(msg || "").trim();
+    if (msg) {
+      const e = new Error(msg);
+      (e as any).cause = result;
+      throw e;
+    }
+  }
+
   throw result;
 };
 

--- a/web-admin/app/composables/api/services/aiSettingService.ts
+++ b/web-admin/app/composables/api/services/aiSettingService.ts
@@ -139,10 +139,16 @@ export class AISettingService {
   /**
    * 获取可用的供应商列表
    */
-  static async getProviders(): Promise<Provider[]> {
+  static async getProviders(modality?: string, env?: string): Promise<Provider[]> {
     const { get } = useApiClient();
+    const params = new URLSearchParams();
+    if (modality) params.append("modality", modality);
+    if (env) params.append("env", env);
+    const url = params.toString()
+      ? `${ApiEndpoints.ADMIN_AGENTS.PROVIDERS}?${params.toString()}`
+      : ApiEndpoints.ADMIN_AGENTS.PROVIDERS;
     const response = await get<ApiResponse<Provider[]>>(
-      ApiEndpoints.ADMIN_AGENTS.PROVIDERS
+      url
     );
     return response.data.providers || [];
   }
@@ -166,7 +172,11 @@ export class AISettingService {
       : ApiEndpoints.ADMIN_AGENTS.MODELS;
 
     const response = await get<ApiResponse<string[]>>(url);
-    return response.data || [];
+    const data: any = response.data as any;
+    if (Array.isArray(data)) return data;
+    if (Array.isArray(data?.models)) return data.models;
+    if (Array.isArray(data?.items)) return data.items;
+    return [];
   }
 
   /**

--- a/web-admin/app/composables/useConfirm.ts
+++ b/web-admin/app/composables/useConfirm.ts
@@ -1,5 +1,5 @@
 import { useOverlay } from '#imports'
-import { LazyCommonConfirmModal } from '#components'
+import { CommonConfirmModal } from '#components'
 
 export type ConfirmOptions = {
   title?: string
@@ -14,7 +14,8 @@ export type ConfirmOptions = {
 
 export const useConfirm = () => {
   const overlay = useOverlay()
-  const modal = overlay.create(LazyCommonConfirmModal)
+  // 不使用 Lazy 版本，避免点击时再去拉取组件 chunk 导致 pending/卡死
+  const modal = overlay.create(CommonConfirmModal)
 
   const confirm = async (opts: ConfirmOptions = {}) => {
     const instance = modal.open({

--- a/web-admin/app/composables/usePrompt.ts
+++ b/web-admin/app/composables/usePrompt.ts
@@ -8,6 +8,8 @@ export type PromptOptions = {
   defaultValue?: string
   confirmLabel?: string
   cancelLabel?: string
+  multiline?: boolean
+  rows?: number
 }
 
 export const usePrompt = () => {
@@ -22,6 +24,8 @@ export const usePrompt = () => {
       defaultValue: opts.defaultValue,
       confirmLabel: opts.confirmLabel,
       cancelLabel: opts.cancelLabel,
+      multiline: opts.multiline,
+      rows: opts.rows,
     })
     const result = await instance.result
     // null 表示取消
@@ -30,4 +34,3 @@ export const usePrompt = () => {
 
   return { prompt }
 }
-

--- a/web-admin/app/pages/agent/index.vue
+++ b/web-admin/app/pages/agent/index.vue
@@ -8,6 +8,9 @@ import { useDualChannelConnection } from "~/composables/agent/useDualChannelConn
 import { useAgentManager } from "~/composables/agent/useAgentManager";
 import { useOneShotAlert } from "~/composables/useOneShotAlert";
 import { useChatSessions } from "~/composables/agent/useChatSessions";
+import { useConfirm } from "~/composables/useConfirm";
+import { useApiClient } from "~/composables/api";
+import { usePrompt } from "~/composables/usePrompt";
 
 definePageMeta({
   title: "Agent 对话",
@@ -16,6 +19,9 @@ definePageMeta({
 });
 
 const { t } = useI18n();
+const { confirm } = useConfirm();
+const { prompt } = usePrompt();
+const { get, put, delete: del } = useApiClient();
 
 // 会话状态管理
 const chatSessions = useChatSessions();
@@ -61,6 +67,43 @@ const { agents } = agentManager;
 const isConnected = computed(() => chat.sseActive.value || chat.wsActive.value);
 const isStreaming = computed(() => chat.isGenerating.value);
 const isTyping = ref(false);
+const isSending = ref(false);
+let createSessionInFlight: Promise<any> | null = null;
+
+// Agent 级模型覆盖（来自 /admin/agents/:id/ai-setting）
+const agentAiSetting = ref<{ provider?: string; model?: string; params?: any } | null>(
+  null
+);
+
+const loadAgentAISetting = async (agentId: number) => {
+  try {
+    const res: any = await get(`/admin/agents/${agentId}/ai-setting`, {
+      params: { env: "dev" },
+      useGlobalLoading: false,
+    });
+    const payload = res?.data ?? res;
+    agentAiSetting.value = {
+      provider: payload?.provider,
+      model: payload?.model,
+      params: payload?.params,
+    };
+  } catch {
+    agentAiSetting.value = null;
+  }
+};
+
+const ensureSessionForSend = async () => {
+  if (currentSessionId.value) return;
+  if (!currentAgentId.value) return;
+  if (!createSessionInFlight) {
+    createSessionInFlight = chatSessions
+      .createSession(currentAgentId.value)
+      .finally(() => {
+        createSessionInFlight = null;
+      });
+  }
+  await createSessionInFlight;
+};
 
 const retryLastMessage = async () => {
   console.log("重试最后一条消息");
@@ -71,7 +114,11 @@ onMounted(async () => {
   try {
     await agentManager.fetchAgents();
     if (agents.value && agents.value.length > 0) {
-      await handleAgentSelect(agents.value[0].id);
+      const last = chatSessions.getLastSelectedAgentId?.() ?? null;
+      const fallbackId = agents.value[0].id;
+      const pickId =
+        last && agents.value.some((a) => a.id === last) ? last : fallbackId;
+      await handleAgentSelect(pickId);
     }
   } catch (e: any) {
     if (!(e?.status === 404 || e?.statusCode === 404)) {
@@ -134,7 +181,14 @@ const handleDeleteSession = async (payload: {
   sessionId: string | number;
 }) => {
   const { agentId, sessionId } = payload;
-  if (!confirm(t("agent.confirmDelete") || "确定删除该会话？")) return;
+  const ok = await confirm({
+    title: t("agent.confirmDelete") || "确定删除该会话？",
+    tone: "danger",
+    confirmColor: "red",
+    confirmLabel: t("common.delete") || "删除",
+    cancelLabel: t("common.cancel") || "取消",
+  });
+  if (!ok) return;
 
   try {
     await chatSessions.deleteSession(agentId, sessionId);
@@ -186,6 +240,7 @@ const handleAgentSelect = async (agentId: number) => {
     chatSessions.selectAgent(agentId);
     await chatSessions.listSessions(agentId);
     chat.clearMessages();
+    await loadAgentAISetting(agentId);
   } catch (error) {
     console.error("选择 Agent 失败:", error);
     notifyOnce("加载会话列表失败", error instanceof Error ? error.message : "");
@@ -194,14 +249,55 @@ const handleAgentSelect = async (agentId: number) => {
 
 const handleSendMessage = async (content: string) => {
   if (!canSendMessage.value) return;
+  if (isSending.value) return;
+  if (chat.isGenerating.value) return;
+  isSending.value = true;
   const meta: any = {};
-  if (currentSessionId.value) meta.sessionId = currentSessionId.value;
-  if (currentAgentId.value) meta.agentId = currentAgentId.value;
-  await chat.sendMessage(content, "chat", meta);
+  try {
+    await ensureSessionForSend();
+    if (currentSessionId.value) meta.sessionId = currentSessionId.value;
+    if (currentAgentId.value) meta.agentId = currentAgentId.value;
+    await chat.sendMessage(content, "chat", meta);
+  } finally {
+    isSending.value = false;
+  }
 };
 
 const handleRetryMessage = async () => {
   await retryLastMessage();
+};
+
+const handleRegenerateFrom = async (messageId: string | number) => {
+  if (isSending.value) return;
+  if (chat.isGenerating.value) return;
+  if (!currentSessionId.value) {
+    // 没有会话就无法从历史消息重新生成
+    return;
+  }
+  const idNum =
+    typeof messageId === "number" ? messageId : parseInt(String(messageId), 10);
+  if (!idNum || Number.isNaN(idNum)) return;
+
+  isSending.value = true;
+  try {
+    const target = chat.messages.value.find((m: any) => m.id === idNum);
+    const defaultValue =
+      target && typeof target.content === "string" ? String(target.content) : "";
+    const edited = await prompt({
+      title: "重新编辑问题",
+      description: "修改这条问题后，将从这里重新生成后续回答。",
+      placeholder: "输入新的问题…",
+      defaultValue,
+      confirmLabel: "保存并重新生成",
+      cancelLabel: "取消",
+      multiline: true,
+      rows: 3,
+    });
+    if (edited == null) return;
+    await chat.regenerateFrom(idNum, "chat", edited);
+  } finally {
+    isSending.value = false;
+  }
 };
 
 const handleClearMessages = () => {
@@ -230,28 +326,60 @@ const handleCloseConfig = () => {
 };
 
 const handleDeleteAgent = async (agentId: number) => {
-  if (confirm(t("agent.confirmDelete"))) {
-    try {
-      await agentManager.deleteAgent(agentId);
-      // 如果删除的是当前选中的 Agent，清空会话状态并选择第一个可用的 Agent
-      if (agentId === currentAgentId.value) {
-        chatSessions.clear();
-        if (agents.value.length > 0) {
-          const first = agents.value[0];
-          if (first) await handleAgentSelect(first.id);
-        }
+  const ok = await confirm({
+    title: t("agent.confirmDelete") || "确定删除该会话？",
+    tone: "danger",
+    confirmColor: "red",
+    confirmLabel: t("common.delete") || "删除",
+    cancelLabel: t("common.cancel") || "取消",
+  });
+  if (!ok) return;
+  try {
+    await agentManager.deleteAgent(agentId);
+    // 如果删除的是当前选中的 Agent，清空会话状态并选择第一个可用的 Agent
+    if (agentId === currentAgentId.value) {
+      chatSessions.clear();
+      if (agents.value.length > 0) {
+        const first = agents.value[0];
+        if (first) await handleAgentSelect(first.id);
       }
-    } catch (error) {
-      console.error("删除 Agent 失败:", error);
     }
+  } catch (error) {
+    console.error("删除 Agent 失败:", error);
   }
 };
 
 const handleSaveAgent = async (config: any) => {
   try {
     if (config.id) {
-      await agentManager.updateAgent(parseInt(config.id), config);
+      const updated = await agentManager.updateAgent(parseInt(config.id), config);
+      const agentId = updated?.id ?? parseInt(config.id);
+
+      // Agent 级 provider/model 覆盖：有选就 upsert；选“系统默认”就 delete（回退）
+      if (config.useSystemModelConfig || !config.provider || !config.model) {
+        try {
+          await del(`/admin/agents/${agentId}/ai-setting`, {
+            params: { env: "dev" },
+            useGlobalLoading: false,
+          });
+        } catch {}
+      } else {
+        await put(
+          `/admin/agents/${agentId}/ai-setting`,
+          {
+            env: "dev",
+            provider: String(config.provider),
+            model: String(config.model),
+            params: {},
+            overrideFlags: { provider: true, model: true },
+            quotaPolicy: {},
+          },
+          { useGlobalLoading: false }
+        );
+      }
+
       await agentManager.fetchAgents();
+      await loadAgentAISetting(agentId);
     } else {
       const newAgent = await agentManager.createAgent({
         key: config.key || `agent_${Date.now()}`,
@@ -260,6 +388,24 @@ const handleSaveAgent = async (config: any) => {
         status: config.isActive ? "active" : "inactive",
         meta: config.meta || {},
       });
+      // 新建后可选写入 agent 级模型覆盖
+      if (!config.useSystemModelConfig && config.provider && config.model) {
+        try {
+          await put(
+            `/admin/agents/${newAgent.id}/ai-setting`,
+            {
+              env: "dev",
+              provider: String(config.provider),
+              model: String(config.model),
+              params: {},
+              overrideFlags: { provider: true, model: true },
+              quotaPolicy: {},
+            },
+            { useGlobalLoading: false }
+          );
+        } catch {}
+      }
+
       await handleAgentSelect(newAgent.id);
     }
     handleCloseConfig();
@@ -279,14 +425,15 @@ const selectedAgent = computed(() => {
 const currentAgentForChat = computed(() => {
   const agent = selectedAgent.value;
   if (!agent) return null;
+  const cfg = agentAiSetting.value;
   return {
     id: agent.id.toString(),
     name: agent.name,
     description: agent.description,
     avatar: "",
-    model: "gpt-3.5-turbo",
+    model: cfg?.model || "gpt-3.5-turbo",
     systemPrompt: "",
-    temperature: 0.7,
+    temperature: cfg?.params?.temperature ?? 0.7,
     maxTokens: 2000,
     topP: 1,
     frequencyPenalty: 0,
@@ -418,6 +565,7 @@ const getAgentIcon = (agent: Agent) => {
             :can-send-message="canSendMessage"
             @send-message="handleSendMessage"
             @retry-message="handleRetryMessage"
+            @regenerate-from="handleRegenerateFrom"
             @clear-messages="handleClearMessages"
           />
         </ClientOnly>

--- a/web-admin/app/pages/plugin-release/MarketplaceListings.vue
+++ b/web-admin/app/pages/plugin-release/MarketplaceListings.vue
@@ -116,7 +116,11 @@
     </UCard>
 
     <!-- 审核操作模态框 -->
-    <UModal v-model="isReviewModalOpen">
+    <UModal
+      v-model="isReviewModalOpen"
+      title="marketplace-listing-review-title"
+      description="marketplace-listing-review-desc"
+    >
       <UCard>
         <template #header>
           <div class="flex items-center justify-between">

--- a/web-admin/app/pages/plugin-release/ReviewDetail.vue
+++ b/web-admin/app/pages/plugin-release/ReviewDetail.vue
@@ -171,7 +171,11 @@
     </div>
 
     <!-- 审核操作模态框 -->
-    <UModal v-model="isReviewModalOpen">
+    <UModal
+      v-model="isReviewModalOpen"
+      title="plugin-release-review-title"
+      description="plugin-release-review-desc"
+    >
       <UCard>
         <template #header>
           <div class="flex items-center justify-between">

--- a/web-admin/app/pages/settings/ai/index.vue
+++ b/web-admin/app/pages/settings/ai/index.vue
@@ -105,9 +105,16 @@
           <div class="mb-4 font-medium text-[var(--text-primary)]">
             {{ currentTitle }} - {{ $t("settings.ai.sections.general") }}
           </div>
+          <p
+            v-if="modality === 'image' || modality === 'video'"
+            class="mb-3 text-xs text-[var(--text-secondary)]"
+          >
+            图像/视频的 Provider 列表已对齐；若某 Provider 在当前模态暂无专用模型，会自动回退展示另一模态的模型（占位）。
+          </p>
           <ProviderModelForm
             :provider-options="providerOptions"
             :model-options="modelOptions"
+            :active-provider="activeProviderForForm"
             :state="currentState"
             @provider-changed="onProviderChanged"
           />
@@ -127,12 +134,14 @@
             :audio-tts="audioTTS"
             :audio-asr="audioASR"
             :video="video"
+            :model3d="model3d"
             :rerank="rerank"
             :image-size-options="imageSizeOptions"
             :image-quality-options="imageQualityOptions"
             :image-format-options="imageFormatOptions"
             :truncate-options="truncateOptions"
             :video-resolution-options="videoResolutionOptions"
+            :model3d-format-options="model3dFormatOptions"
             :voice-options="voiceOptions"
             :audio-format-options="audioFormatOptions"
             :audio-quality-options="audioQualityOptions"
@@ -177,6 +186,7 @@ type Modality =
   | "audio_tts"
   | "audio_asr"
   | "video"
+  | "model3d"
   | "rerank";
 
 // 使用 AI 设置 store
@@ -215,6 +225,7 @@ const modalityTabs = [
   { key: "audio_tts", label: "语音合成", icon: "i-heroicons-speaker-wave" },
   { key: "audio_asr", label: "语音识别", icon: "i-heroicons-microphone" },
   { key: "video", label: "视频生成", icon: "i-heroicons-video-camera" },
+  { key: "model3d", label: "3D 生成", icon: "i-heroicons-cube" },
   { key: "rerank", label: "重排序", icon: "i-heroicons-arrows-up-down" },
 ] as const;
 
@@ -274,6 +285,21 @@ const providerOptions = computed<SelectOption[]>(() => {
   return [placeholder, ...options];
 });
 
+const activeProviderForForm = computed(() => {
+  const pid = String(currentState.value.provider ?? "").trim();
+  if (!pid) return null;
+  const hit =
+    (aiSettingsStore.providers ?? []).find(
+      (p: Provider) => String(p.ID ?? "").trim().toLowerCase() === pid.toLowerCase()
+    ) ?? null;
+  if (!hit) return null;
+  return {
+    id: hit.ID,
+    name: hit.Name,
+    auth: hit.auth ?? undefined,
+  };
+});
+
 // 当前选中的 Provider
 const activeProvider = computed(
   () => aiSettingsStore.activeProfile?.provider || null
@@ -289,7 +315,10 @@ const activeModel = computed(
 type BaseConn = {
   provider: string | null;
   model: string | null;
+  authMode: string;
   apiKey: string;
+  secretId: string;
+  secretKey: string;
   baseURL: string;
   region: string;
   organization: string;
@@ -306,7 +335,10 @@ const llm = reactive<
 >({
   provider: null,
   model: null,
+  authMode: "",
   apiKey: "",
+  secretId: "",
+  secretKey: "",
   baseURL: "",
   region: "",
   organization: "",
@@ -324,9 +356,12 @@ const image = reactive<
     promptHint: string;
   }
 >({
-  provider: "OpenAI",
+  provider: "openai",
   model: "gpt-image-1",
+  authMode: "",
   apiKey: "",
+  secretId: "",
+  secretKey: "",
   baseURL: "",
   region: "",
   organization: "",
@@ -339,9 +374,12 @@ const image = reactive<
 const embedding = reactive<
   BaseConn & { dimensions: number; truncate: string; batch: number }
 >({
-  provider: "OpenAI",
+  provider: "openai",
   model: "text-embedding-3-small",
+  authMode: "",
   apiKey: "",
+  secretId: "",
+  secretKey: "",
   baseURL: "",
   region: "",
   organization: "",
@@ -358,9 +396,12 @@ const audioTTS = reactive<
     quality: string;
   }
 >({
-  provider: "OpenAI",
-  model: "tts-1",
+  provider: "openai",
+  model: "gpt-4o-mini-tts",
+  authMode: "",
   apiKey: "",
+  secretId: "",
+  secretKey: "",
   baseURL: "",
   region: "",
   organization: "",
@@ -378,9 +419,12 @@ const audioASR = reactive<
     prompt: string;
   }
 >({
-  provider: "OpenAI",
+  provider: "openai",
   model: "whisper-1",
+  authMode: "",
   apiKey: "",
+  secretId: "",
+  secretKey: "",
   baseURL: "",
   region: "",
   organization: "",
@@ -398,15 +442,37 @@ const video = reactive<
     promptHint: string;
   }
 >({
-  provider: "OpenAI",
+  provider: "openai",
   model: "sora-preview",
+  authMode: "",
   apiKey: "",
+  secretId: "",
+  secretKey: "",
   baseURL: "",
   region: "",
   organization: "",
   resolution: "1080p",
   fps: 24,
   maxDurationSec: 10,
+  promptHint: "",
+});
+
+const model3d = reactive<
+  BaseConn & {
+    outputFormat: string;
+    promptHint: string;
+  }
+>({
+  provider: "hunyuan",
+  model: "HY-3D-Express",
+  authMode: "openai",
+  apiKey: "",
+  secretId: "",
+  secretKey: "",
+  baseURL: "",
+  region: "",
+  organization: "",
+  outputFormat: "glb",
   promptHint: "",
 });
 
@@ -417,9 +483,12 @@ const rerank = reactive<
     maxChunksPerDoc: number;
   }
 >({
-  provider: "OpenAI",
+  provider: "openai",
   model: "text-embedding-3-large",
+  authMode: "",
   apiKey: "",
+  secretId: "",
+  secretKey: "",
   baseURL: "",
   region: "",
   organization: "",
@@ -445,6 +514,8 @@ const currentTitle = computed(() => {
       return "语音识别";
     case "video":
       return "视频生成";
+    case "model3d":
+      return "3D 生成";
     case "rerank":
       return "重排序";
     default:
@@ -467,6 +538,8 @@ const currentState = computed<any>({
         return audioASR;
       case "video":
         return video;
+      case "model3d":
+        return model3d;
       case "rerank":
         return rerank;
       default:
@@ -504,86 +577,223 @@ const modelOptions = computed<SelectOption[]>(() => {
   return [placeholder, ...options];
 });
 
+const draftByProviderKey = reactive<Record<string, Record<string, any>>>({});
+
+function normalizeProviderKey(provider?: string | null) {
+  return String(provider ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function draftKey(
+  provider?: string | null,
+  envVal?: string | null,
+  modalityVal?: string | null
+) {
+  const p = normalizeProviderKey(provider);
+  const e = String(envVal || "default").trim();
+  const m = String(modalityVal || "llm").trim();
+  return `${e}::${m}::${p}`;
+}
+
+function getDraftableFields(modalityVal?: string | null): string[] {
+  const m = String(modalityVal || "").trim();
+  const base = [
+    "model",
+    "authMode",
+    "apiKey",
+    "secretId",
+    "secretKey",
+    "baseURL",
+    "organization",
+    "region",
+    "azureDeployment",
+  ];
+  switch (m) {
+    case "llm":
+      return [...base, "temperature", "maxTokens", "topP", "stream"];
+    case "image":
+      return [...base, "size", "quality", "format", "promptHint"];
+    case "embedding":
+      return [...base, "dimensions", "truncate", "batch"];
+    case "audio_tts":
+      return [...base, "voice", "speed", "format", "quality"];
+    case "audio_asr":
+      return [...base, "language", "responseFormat", "temperature", "prompt"];
+    case "video":
+      return [...base, "resolution", "fps", "maxDurationSec", "promptHint"];
+    case "model3d":
+      return [...base, "outputFormat", "promptHint"];
+    case "rerank":
+      return [...base, "topK", "returnDocuments", "maxChunksPerDoc"];
+    default:
+      return base;
+  }
+}
+
+function applyModalityDefaults(state: Record<string, any>, modalityVal?: string | null) {
+  const m = String(modalityVal || "").trim();
+  switch (m) {
+    case "llm":
+      state.temperature = 0.7;
+      state.maxTokens = 4096;
+      state.topP = 1;
+      state.stream = true;
+      if ("authMode" in state) state.authMode = "";
+      break;
+    case "image":
+      state.size = "1024x1024";
+      state.quality = "standard";
+      state.format = "png";
+      state.promptHint = "";
+      if ("authMode" in state) state.authMode = "";
+      break;
+    case "embedding":
+      state.dimensions = 0;
+      state.truncate = "none";
+      state.batch = 1;
+      if ("authMode" in state) state.authMode = "";
+      break;
+    case "audio_tts":
+      state.voice = "alloy";
+      state.speed = 1.0;
+      state.format = "mp3";
+      state.quality = "standard";
+      if ("authMode" in state) state.authMode = "";
+      break;
+    case "audio_asr":
+      state.language = "auto";
+      state.responseFormat = "json";
+      state.temperature = 0;
+      state.prompt = "";
+      if ("authMode" in state) state.authMode = "";
+      break;
+    case "video":
+      state.resolution = "1080p";
+      state.fps = 24;
+      state.maxDurationSec = 10;
+      state.promptHint = "";
+      if ("authMode" in state) state.authMode = "";
+      break;
+    case "model3d":
+      state.outputFormat = "glb";
+      state.promptHint = "";
+      if ("authMode" in state) state.authMode = "openai";
+      break;
+    case "rerank":
+      state.topK = 10;
+      state.returnDocuments = true;
+      state.maxChunksPerDoc = 10;
+      if ("authMode" in state) state.authMode = "";
+      break;
+  }
+}
+
+function persistProviderDraft(
+  provider?: string | null,
+  envVal?: string | null,
+  modalityVal?: string | null,
+  stateOverride?: Record<string, any>
+) {
+  const p = normalizeProviderKey(provider);
+  if (!p) return;
+  const state = (stateOverride || (currentState.value as any)) as Record<string, any>;
+  const k = draftKey(p, envVal, modalityVal);
+  const fields = getDraftableFields(modalityVal);
+  const snapshot: Record<string, any> = {};
+  for (const f of fields) {
+    snapshot[f] = state[f];
+  }
+  draftByProviderKey[k] = snapshot;
+}
+
+function restoreProviderDraft(
+  provider?: string | null,
+  envVal?: string | null,
+  modalityVal?: string | null,
+  stateOverride?: Record<string, any>
+) {
+  const p = normalizeProviderKey(provider);
+  const state = (stateOverride || (currentState.value as any)) as Record<string, any>;
+  if (!p) return;
+
+  // 1) 优先使用“该 provider 的草稿”（避免切换 provider 时把别人的 key 带过去）
+  const draft = draftByProviderKey[draftKey(p, envVal, modalityVal)];
+  if (draft) {
+    const fields = getDraftableFields(modalityVal);
+    for (const f of fields) {
+      if (f in draft) state[f] = draft[f];
+    }
+    return;
+  }
+
+  // 2) 没有草稿：重置为默认参数 + 回填已保存的非敏感字段（注意：后端会脱敏，不会返回 api_key）
+  applyModalityDefaults(state, modalityVal);
+
+  const getter =
+    typeof aiSettingsStore.getCredentialByProvider === "function"
+      ? aiSettingsStore.getCredentialByProvider
+      : null;
+  const data = (getter ? getter(p)?.data ?? {} : {}) as Record<string, any>;
+  const getString = (key: string) => (typeof data[key] === "string" ? data[key] : "");
+
+  // 由 ProviderModelForm 兜底选择默认 authMode；这里仅在后端返回时回填
+  state.authMode = getString("auth_mode");
+  state.apiKey = ""; // 关键：不同 provider 的 key 必须隔离
+  state.secretKey = ""; // 关键：敏感字段不从后端回填
+  state.secretId = getString("secret_id");
+  state.baseURL = getString("base_url");
+  state.organization = getString("organization");
+  state.region = getString("region");
+  if ("azureDeployment" in state) state.azureDeployment = getString("azure_deployment");
+}
+
 async function onProviderChanged(nextProvider?: string) {
   const rawProvider = nextProvider ?? currentState.value.provider;
   const currentModality = modality.value;
+  const envSnapshot = env.value;
+  const modalitySnapshot = modality.value;
 
   // 关键：参数不全就短路，但不清空 models
   if (!rawProvider || !currentModality) {
-    syncCredentialFieldsForProvider(rawProvider);
+    restoreProviderDraft(rawProvider, envSnapshot, modalitySnapshot);
     return;
   }
 
   try {
     // ✅ 直接传原始值，让 store 内部处理规范化
     await aiSettingsStore.fetchModels(rawProvider, currentModality, env.value);
-    const models = aiSettingsStore.models ?? [];
-    if (models.length && !models.includes(currentState.value.model)) {
-      currentState.value.model = models[0];
-    }
   } catch (error) {
     console.error("获取模型列表失败:", error);
     // 这里不清空，保持上一次成功值
   }
 
-  syncCredentialFieldsForProvider(rawProvider);
-}
+  restoreProviderDraft(rawProvider, envSnapshot, modalitySnapshot);
 
-function syncCredentialFieldsForProvider(provider?: string | null) {
-  const targetProvider = (provider ?? "").trim();
-  const state = currentState.value as BaseConn & Record<string, any>;
-  const getter =
-    typeof aiSettingsStore.getCredentialByProvider === "function"
-      ? aiSettingsStore.getCredentialByProvider
-      : null;
-  const data = (getter ? getter(targetProvider)?.data ?? {} : {}) as Record<
-    string,
-    any
-  >;
-  const assign = (field: string, value: string) => {
-    state[field] = value;
-  };
-
-  const clearConnectionFields = () => {
-    assign("baseURL", "");
-    assign("organization", "");
-    assign("region", "");
-    if ("azureDeployment" in state) {
-      assign("azureDeployment", "");
+  // restoreDraft 可能会把旧 model 带回来；这里再做一次兜底校验
+  const models = aiSettingsStore.models ?? [];
+  if (models.length) {
+    const curModel = currentState.value.model;
+    if (!curModel || !models.includes(curModel)) {
+      currentState.value.model = models[0];
     }
-  };
-
-  if (!targetProvider) {
-    clearConnectionFields();
-    return;
-  }
-
-  const getString = (key: string) => {
-    const val = data[key];
-    return typeof val === "string" ? val : "";
-  };
-
-  const baseURL = getString("base_url");
-  const organization = getString("organization");
-  const region = getString("region");
-  const azureDeployment = getString("azure_deployment");
-
-  assign("baseURL", baseURL);
-  assign("organization", organization);
-  assign("region", region);
-  if ("azureDeployment" in state) {
-    assign("azureDeployment", azureDeployment);
+  } else {
+    // ✅ 该 provider 在当前模态下没有可用模型：清空，避免出现 provider=Coze 但 model=OpenAI 的错配显示
+    currentState.value.model = "";
   }
 }
+
+// 旧实现：syncCredentialFieldsForProvider（已用 restoreProviderDraft 替代，避免 apiKey/参数串台）
 
 /**
  * 选项集合（传给 ModalityParamsForm）
  */
 const imageSizeOptions = ["256x256", "512x512", "1024x1024"];
 const imageQualityOptions = ["standard", "hd"];
-const imageFormatOptions = ["png", "jpeg", "webp"];
+  const imageFormatOptions = ["png", "jpeg", "webp"];
 const truncateOptions = ["none", "start", "end"];
 const videoResolutionOptions = ["720p", "1080p", "4k"];
+const model3dFormatOptions = ["glb", "gltf", "obj", "fbx"];
 
 // 新增音频TTS选项
 const voiceOptions = ["alloy", "echo", "fable", "onyx", "nova", "shimmer"];
@@ -601,7 +811,10 @@ function buildPayloadForCurrentModality(promptOverride?: string) {
   const baseConn = {
     provider: currentState.value.provider ?? "",
     model: currentState.value.model ?? "",
+    authMode: currentState.value.authMode ?? "",
     apiKey: currentState.value.apiKey ?? "",
+    secretId: currentState.value.secretId ?? "",
+    secretKey: currentState.value.secretKey ?? "",
     baseURL: currentState.value.baseURL ?? "",
     organization: currentState.value.organization ?? "",
     region: currentState.value.region ?? "",
@@ -666,6 +879,13 @@ function buildPayloadForCurrentModality(promptOverride?: string) {
         promptHint: video.promptHint,
       };
       break;
+    case "model3d":
+      body = {
+        ...baseConn,
+        outputFormat: model3d.outputFormat,
+        promptHint: model3d.promptHint,
+      };
+      break;
     case "rerank":
       body = {
         ...baseConn,
@@ -717,13 +937,14 @@ async function saveSettings() {
 
 async function resetSettings() {
   const resetMap: Record<Modality, { provider: string; model: string }> = {
-    llm: { provider: "OpenAI", model: "gpt-4o-mini" },
-    image: { provider: "OpenAI", model: "dall-e-3" },
-    embedding: { provider: "OpenAI", model: "text-embedding-3-small" },
-    audio_tts: { provider: "OpenAI", model: "tts-1" },
-    audio_asr: { provider: "OpenAI", model: "whisper-1" },
-    video: { provider: "OpenAI", model: "sora-preview" },
-    rerank: { provider: "OpenAI", model: "text-embedding-3-large" },
+    llm: { provider: "openai", model: "gpt-4o-mini" },
+    image: { provider: "openai", model: "gpt-image-1" },
+    embedding: { provider: "openai", model: "text-embedding-3-small" },
+    audio_tts: { provider: "openai", model: "gpt-4o-mini-tts" },
+    audio_asr: { provider: "openai", model: "whisper-1" },
+    video: { provider: "openai", model: "sora-preview" },
+    model3d: { provider: "hunyuan", model: "HY-3D-Express" },
+    rerank: { provider: "openai", model: "text-embedding-3-large" },
   };
   const cur = currentState.value as BaseConn;
   const def = resetMap[modality.value];
@@ -745,9 +966,13 @@ async function testConnection() {
       currentState.value.provider || "",
       payload
     );
+    // 测试成功后后端会自动保存该 provider 的凭据（不激活默认路由），这里刷新一下非敏感凭据元数据
+    try {
+      await aiSettingsStore.fetchCredentials(env.value);
+    } catch {}
     toast.add({
       title: "连接测试成功",
-      description: `${currentTitle.value} 连接正常`,
+      description: `${currentTitle.value} 连接正常（凭据已保存，未改变默认路由）`,
       color: "success",
     });
   } catch (error) {
@@ -789,6 +1014,15 @@ async function testQuickCall() {
 }
 async function refreshStateForEnvAndModality() {
   aiSettingsStore.setCurrentEnv(env.value);
+  try {
+    await aiSettingsStore.fetchProviders(modality.value, env.value);
+  } catch (error) {
+    toast.add({
+      title: "加载 Provider 列表失败",
+      description: getErrorMessage(error),
+      color: "error",
+    });
+  }
   await loadActiveConfiguration();
   if (!currentState.value.provider) {
     loadExistingConfiguration();
@@ -852,6 +1086,9 @@ function loadExistingConfiguration() {
   // credential.data 也兜底
   const cd = credential.data ?? {};
   currentState.value.apiKey = cd.api_key ?? currentState.value.apiKey ?? "";
+  currentState.value.secretId = cd.secret_id ?? currentState.value.secretId ?? "";
+  // SecretKey 不会从后端回填（脱敏/不回传）
+  currentState.value.secretKey = "";
   currentState.value.baseURL = cd.base_url ?? currentState.value.baseURL ?? "";
   currentState.value.organization =
     cd.organization ?? currentState.value.organization ?? "";
@@ -899,10 +1136,55 @@ async function loadActiveConfiguration() {
 // 监听 provider 改变（初始化已手动调用过）
 watch(
   () => currentState.value.provider,
-  (p) => {
-    if (p) onProviderChanged(p);
+  (next, prev) => {
+    const envSnapshot = env.value;
+    const modalitySnapshot = modality.value;
+    // 在 provider 切换前，先把旧 provider 的输入保存为草稿（避免切回时丢失）
+    if (prev) {
+      persistProviderDraft(prev, envSnapshot, modalitySnapshot);
+    }
+    if (next) onProviderChanged(next);
   },
   { immediate: false }
+);
+
+watch(
+  () => [currentState.value.provider, modality.value, aiSettingsStore.providers] as const,
+  () => {
+    const ap = activeProviderForForm.value;
+    const modes = ap?.auth?.modes ?? [];
+    if (!Array.isArray(modes) || modes.length === 0) return;
+    if (!currentState.value.authMode) {
+      // 默认优先第一个（hunyuan.yaml 里把 openai 放第一个）
+      currentState.value.authMode = modes[0].id;
+    }
+  }
+);
+
+watch(
+  () => [currentState.value.provider, currentState.value.authMode, modality.value, aiSettingsStore.providers] as const,
+  () => {
+    const ap = activeProviderForForm.value;
+    const modes = ap?.auth?.modes ?? [];
+    if (!Array.isArray(modes) || modes.length === 0) return;
+
+    const modeId = String(currentState.value.authMode || "").trim();
+    if (!modeId) return;
+    const hit = modes.find((m: any) => String(m?.id || "").trim() === modeId);
+    const defBase = String(hit?.defaults?.base_url || "").trim();
+    if (!defBase) return;
+
+    const curBase = String(currentState.value.baseURL || "").trim();
+    // 仅在明显需要时覆盖：空 / 误填 tc3 endpoint / 忘了 /v1
+    const lower = curBase.toLowerCase();
+    const isTC3 = lower.includes("tencentcloudapi.com");
+    const isHunyuanOpenAIHost = lower.includes("hunyuan.cloud.tencent.com");
+    const missingV1 = modeId === "openai" && curBase && !lower.includes("/v1");
+    const needSwitchToTC3 = modeId === "tc3" && curBase && (isHunyuanOpenAIHost || lower.includes("/v1"));
+    if (!curBase || (modeId === "openai" && (isTC3 || missingV1)) || needSwitchToTC3) {
+      currentState.value.baseURL = defBase;
+    }
+  }
 );
 
 // 监听模态切换，重新加载配置

--- a/web-admin/app/plugins/01.unhandled-errors.client.ts
+++ b/web-admin/app/plugins/01.unhandled-errors.client.ts
@@ -1,0 +1,42 @@
+export default defineNuxtPlugin(() => {
+  const IGNORED_MESSAGES = [
+    "Could not establish connection. Receiving end does not exist.",
+    "The message port closed before a response was received.",
+    "A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received.",
+    "Extension context invalidated.",
+  ];
+
+  const getMessage = (reason: unknown) => {
+    if (!reason) return "";
+    if (typeof reason === "string") return reason;
+    if (reason instanceof Error) return reason.message || "";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const maybeMsg = (reason as any)?.message;
+    return typeof maybeMsg === "string" ? maybeMsg : "";
+  };
+
+  const shouldIgnore = (reason: unknown) => {
+    const msg = getMessage(reason);
+    if (!msg) return false;
+    return IGNORED_MESSAGES.some((m) => msg.includes(m));
+  };
+
+  // 一些浏览器扩展会向页面注入脚本并通过 message channel 通信；
+  // 当页面刷新/路由切换/receiver 不存在时会抛出以上错误。
+  // 这些错误与 PowerX 本身无关，但可能会触发 Nuxt 全局错误处理导致“卡死/黑屏/Loading 不结束”。
+  window.addEventListener("unhandledrejection", (event) => {
+    if (!shouldIgnore(event.reason)) return;
+    event.preventDefault();
+    console.debug("[unhandledrejection][ignored]", getMessage(event.reason));
+  });
+
+  window.addEventListener("error", (event) => {
+    if (!shouldIgnore(event.error ?? event.message)) return;
+    event.preventDefault();
+    console.debug(
+      "[window.error][ignored]",
+      getMessage(event.error ?? event.message)
+    );
+  });
+});
+

--- a/web-admin/app/plugins/60.mdc-prose-overrides.client.ts
+++ b/web-admin/app/plugins/60.mdc-prose-overrides.client.ts
@@ -1,0 +1,10 @@
+import ProsePre from "~/components/prose/ProsePre.vue";
+import ProseA from "~/components/prose/ProseA.vue";
+
+export default defineNuxtPlugin((nuxtApp) => {
+  // MDCRenderer 在运行时通过 resolveComponent("ProsePre") 渲染代码块；
+  // Nuxt 的 components auto-import 是编译期能力，无法被 resolveComponent 直接发现，
+  // 因此需要在这里把覆盖组件注册到 vueApp 的全局组件表里。
+  nuxtApp.vueApp.component("ProsePre", ProsePre);
+  nuxtApp.vueApp.component("ProseA", ProseA);
+});

--- a/web-admin/app/plugins/global-loading.ts
+++ b/web-admin/app/plugins/global-loading.ts
@@ -7,15 +7,23 @@ export default defineNuxtPlugin((nuxtApp) => {
     autoVisible.value = navPending.value || reqPending.value > 0;
   };
 
+  const clearNavPending = () => {
+    navPending.value = false;
+    recalc();
+  };
+
   // 路由开始/结束
   nuxtApp.hook("page:start", () => {
     navPending.value = true;
     recalc();
   });
   nuxtApp.hook("page:finish", () => {
-    navPending.value = false;
-    recalc();
+    clearNavPending();
   });
+  // 兜底：导航/渲染过程如果抛错，避免全局 Loading 永久挂起
+  nuxtApp.hook("page:error", () => clearNavPending());
+  nuxtApp.hook("app:error", () => clearNavPending());
+  nuxtApp.hook("vue:error", () => clearNavPending());
 
   // 监听 useFetch/asyncData 等
   nuxtApp.hook("app:fetch:before", () => {

--- a/web-admin/app/stores/aiSettings.ts
+++ b/web-admin/app/stores/aiSettings.ts
@@ -164,9 +164,11 @@ export const useAISettingsStore = defineStore("aiSettings", {
     /**
      * 获取供应商列表
      */
-    async fetchProviders() {
+    async fetchProviders(modality?: string, env?: string) {
       try {
-        const providers = await AISettingService.getProviders();
+        const targetEnv = env || this.currentEnv || "default";
+        const normModality = modality ? this.mapModality(modality) : undefined;
+        const providers = await AISettingService.getProviders(normModality, targetEnv);
         this.providers = providers;
       } catch (error) {
         console.error("获取供应商列表失败:", error);
@@ -219,23 +221,39 @@ export const useAISettingsStore = defineStore("aiSettings", {
      * 模态映射
      */
     mapModality(modality: string): string {
-      switch (modality) {
+      const v = String(modality || "").trim().toLowerCase();
+      switch (v) {
+        // 后端 contract.Modality
         case "llm":
-          return "chat"; // 或 'text' / 'completion'
+          return "llm";
         case "image":
           return "image";
         case "embedding":
           return "embedding";
         case "audio_tts":
-          return "tts";
+          return "audio_tts";
         case "audio_asr":
-          return "asr";
+          return "audio_asr";
         case "video":
           return "video";
+        case "model3d":
+        case "model_3d":
+        case "3d":
+          return "model3d";
         case "rerank":
           return "rerank";
+
+        // 兼容旧/别名输入
+        case "chat":
+        case "text":
+        case "completion":
+          return "llm";
+        case "tts":
+          return "audio_tts";
+        case "asr":
+          return "audio_asr";
         default:
-          return modality;
+          return v || modality;
       }
     },
 

--- a/web-admin/i18n/locales/en.json
+++ b/web-admin/i18n/locales/en.json
@@ -44,7 +44,9 @@
     "cancel": "Cancel",
     "save": "Save",
     "reload": "Reload",
-    "reset": "Reset"
+    "reset": "Reset",
+    "scrollToBottom": "Scroll to bottom",
+    "newMessages": "{count} new messages"
   },
   "organization": {
     "description": "Manage your organization, members and permissions.",
@@ -475,7 +477,32 @@
       "model": "Model",
       "temperature": "Temperature",
       "ctrlEnterToSend": "Ctrl+Enter to send",
-      "enterNewLine": "Enter new line"
+      "enterNewLine": "Enter new line",
+      "enterToSend": "Enter to send",
+      "shiftEnterNewLine": "Shift+Enter new line",
+      "newSession": "New session",
+      "untitledSession": "Untitled session",
+      "responding": "Responding",
+      "generating": "Generating",
+      "you": "You",
+      "assistant": "Assistant",
+      "system": "System",
+      "typing": "Typing",
+      "agentTyping": "Agent is typing...",
+      "cancel": "Cancel",
+      "clear": "Clear",
+      "realtimeFailed": "Realtime connection failed",
+      "errors": {
+        "loadSessionsFailed": "Failed to load sessions",
+        "loadMoreSessionsFailed": "Failed to load more sessions",
+        "createSessionFailed": "Failed to create session",
+        "createSessionFailedNoData": "Failed to create session: empty response",
+        "deleteSessionFailed": "Failed to delete session",
+        "renameSessionFailed": "Failed to rename session",
+        "archiveSessionFailed": "Failed to archive session",
+        "loadMessagesFailed": "Failed to load messages",
+        "loadMoreMessagesFailed": "Failed to load more messages"
+      }
     }
   },
   "pluginRelease": {

--- a/web-admin/i18n/locales/ja.json
+++ b/web-admin/i18n/locales/ja.json
@@ -4,7 +4,9 @@
   "register": "登録",
   "common": {
     "language": "言語",
-    "reload": "再読み込み"
+    "reload": "再読み込み",
+    "scrollToBottom": "一番下へ",
+    "newMessages": "新着 {count} 件"
   },
   "user": {
     "admin": "管理者"

--- a/web-admin/i18n/locales/ko.json
+++ b/web-admin/i18n/locales/ko.json
@@ -4,7 +4,9 @@
   "register": "회원가입",
   "common": {
     "language": "언어",
-    "reload": "새로고침"
+    "reload": "새로고침",
+    "scrollToBottom": "맨 아래로",
+    "newMessages": "새 메시지 {count}개"
   },
   "user": {
     "admin": "관리자"

--- a/web-admin/i18n/locales/zh.json
+++ b/web-admin/i18n/locales/zh.json
@@ -56,9 +56,12 @@
     "settings": "设置",
     "trash": "回收站",
     "cancel": "取消",
+    "delete": "删除",
     "save": "保存",
     "reload": "重新加载",
-    "reset": "重置"
+    "reset": "重置",
+    "scrollToBottom": "回到底部",
+    "newMessages": "{count} 条新消息"
   },
   "organization": {
     "description": "管理组织、成员与权限。",
@@ -530,6 +533,7 @@
     }
   },
   "agent": {
+    "confirmDelete": "确定删除吗？",
     "selector": {
       "pickAgent": "选择一个智能体",
       "editAgent": "编辑智能体",
@@ -539,6 +543,11 @@
       "totalCount": "总数",
       "newSession": "新建会话",
       "recents": "最近会话",
+      "pin": "置顶",
+      "pinned": "已置顶",
+      "rename": "重命名",
+      "renameSession": "重命名会话",
+      "delete": "删除",
       "noSessions": "暂无会话"
     },
     "config": {
@@ -562,10 +571,56 @@
         "analyst": "分析助手",
         "analystPrompt": "分析助手提示词"
       },
+      "createTitle": "新建智能体",
+      "editTitle": "编辑智能体",
+      "basicInfo": "基本信息",
+      "name": "名称",
+      "namePlaceholder": "请输入名称",
       "title": "标题",
       "description": "描述",
+      "descriptionPlaceholder": "请输入描述（可选）",
+      "avatar": "头像",
+      "avatarPlaceholder": "请输入头像 URL（可选）",
+      "status": "状态",
+      "active": "启用",
+      "inactive": "停用",
+      "modelConfig": "模型配置",
+      "useSystemModelConfig": "使用系统默认模型配置",
+      "onlyShowConfigured": "仅显示已配置（测试通过）",
+      "onlyConfigured": "仅已配置",
+      "showAll": "显示全部",
+      "noConfiguredHint": "暂无已配置项，筛选可能为空",
+      "notConfigured": "未配置",
+      "inheritEnabled": "已启用",
+      "inheritDisabled": "已关闭",
       "selectProvider": "选择提供商",
-      "selectModel": "选择模型"
+      "model": "模型",
+      "selectModel": "选择模型",
+      "temperature": "随机性",
+      "conservative": "更保守",
+      "creative": "更创意",
+      "maxTokens": "最大 Tokens",
+      "maxTokensPlaceholder": "例如 2048",
+      "systemPrompt": "系统提示词",
+      "usePreset": "使用预设",
+      "systemPromptPlaceholder": "请输入系统提示词（可选）",
+      "capability": "能力",
+      "advancedSettings": "高级设置",
+      "contextWindow": "上下文窗口",
+      "contextWindowPlaceholder": "例如 8k / 32k（可选）",
+      "responseFormat": "响应格式",
+      "formats": {
+        "text": "纯文本",
+        "markdown": "Markdown",
+        "json": "JSON"
+      },
+      "streaming": "流式输出",
+      "streamingEnabled": "已开启",
+      "streamingDisabled": "已关闭",
+      "reset": "重置",
+      "cancel": "取消",
+      "save": "保存",
+      "update": "更新"
     },
     "chat": {
       "defaultAgent": "默认智能体",
@@ -578,7 +633,32 @@
       "model": "模型",
       "temperature": "随机性",
       "ctrlEnterToSend": "Ctrl+Enter 发送",
-      "enterNewLine": "Enter 换行"
+      "enterNewLine": "Enter 换行",
+      "enterToSend": "Enter 发送",
+      "shiftEnterNewLine": "Shift+Enter 换行",
+      "newSession": "新会话",
+      "untitledSession": "未命名会话",
+      "responding": "正在回复",
+      "generating": "生成中",
+      "you": "你",
+      "assistant": "助手",
+      "system": "系统",
+      "typing": "输入中",
+      "agentTyping": "智能体正在输入...",
+      "cancel": "取消",
+      "clear": "清空",
+      "realtimeFailed": "实时连接失败",
+      "errors": {
+        "loadSessionsFailed": "加载会话列表失败",
+        "loadMoreSessionsFailed": "加载更多会话失败",
+        "createSessionFailed": "创建会话失败",
+        "createSessionFailedNoData": "创建会话失败：响应数据为空",
+        "deleteSessionFailed": "删除会话失败",
+        "renameSessionFailed": "重命名会话失败",
+        "archiveSessionFailed": "归档会话失败",
+        "loadMessagesFailed": "加载会话消息失败",
+        "loadMoreMessagesFailed": "加载更多消息失败"
+      }
     }
   },
   "pluginRelease": {

--- a/web-admin/nuxt.config.ts
+++ b/web-admin/nuxt.config.ts
@@ -79,8 +79,20 @@ export default defineNuxtConfig({
     "@nuxt/ui",
     "@nuxt/icon",
     "@nuxtjs/i18n",
+    "@nuxtjs/mdc",
     "@pinia/nuxt",
   ],
+  mdc: {
+    // 开启 GFM：自动识别裸 URL 为链接（如 https://golang.org/doc/）
+    remarkPlugins: {
+      "remark-emoji": {},
+      "remark-gfm": {},
+    },
+    // 聊天场景不需要“标题锚点链接”，否则会让标题看起来像超链接
+    headings: {
+      anchorLinks: false,
+    },
+  },
   css: ["~/assets/css/main.css", "@/assets/scss/main.scss"],
   compatibilityDate: "2024-11-01",
   ui: { fonts: false },
@@ -94,12 +106,15 @@ export default defineNuxtConfig({
   i18n: {
     defaultLocale: process.env.NUXT_DEFAULT_LANGUAGE || "zh",
     strategy: "no_prefix",
+    lazy: true,
     locales: [
       { code: "zh", name: "简体中文", file: "zh.json" },
       { code: "en", name: "English", file: "en.json" },
       { code: "ja", name: "日本語", file: "ja.json" },
       { code: "ko", name: "한국어", file: "ko.json" },
     ],
+    // 注意：langDir 是相对于 i18nDir（默认是 `i18n/`）的
+    // 语言包实际目录：`web-admin/i18n/locales/*.json`
     langDir: "locales",
     detectBrowserLanguage: {
       enabled: false,


### PR DESCRIPTION
  - 修复聊天“发消息后一直挂着/无反馈”：前端 SSE 解析改为按 SSE 规范“空行分隔事件块”缓冲解析，支持跨 chunk 的多行 data:，并在连接结束时 flush 残留 buffer，避 免丢 final/end（web-admin/app/composables/agent/useDualChannelConnection.ts）。
  - SSE 连接策略对齐 ChatGPT 体验：仅在切换会话/切换智能体/关闭页面时断开；连接自然结束或收到 FINAL/END/[DONE] 会正确收尾清状态，避免永久“生成中”（同上）。
  - 增加后端兜底心跳与超时：Engine 每 15s 发 event: heartbeat，并设置整体 10min 超时，超时会下发 error + end，避免后端/模型卡死导致前端永远等待（backend/ internal/server/agent/runtime/engine.go）。
  - 修复后端 panic：eino driver 增加缺配置校验、stream goroutine recover，LLM 调用失败不再吞错，确保前端能收到 error 事件（backend/internal/server/agent/ drivers/eino/agent.go 等）。
  - LLM Provider 默认超时调整：OpenAI/Hunyuan 默认 HTTP 超时从 30s 提升到 10min，避免长对话被 30s 掐断（backend/internal/server/agent/drivers/eino/llm/ openai.go、.../hunyuan.go）。
  - 支持“从某条问题重新编辑并重新生成”：前端提供“重新编辑”入口并携带 regen_from_message_id；后端支持裁剪该消息之后的历史、可更新该条 user message 内容后重新 执行（web-admin/app/components/common/PromptModal.vue、web-admin/app/pages/agent/index.vue、backend/internal/transport/http/admin/agent/chat_handler.go、 backend/internal/service/agent/chat_history_service.go）。
  - Markdown/代码块显示接近 ChatGPT：引入 @nuxtjs/mdc 渲染、覆盖 ProsePre/ProseA（代码块卡片+复制、外链新开并带下划线、标题不自动变链接），并修复 ProsePre 组 件缺失报错（web-admin/app/components/agent/AgentMarkdown.vue、web-admin/app/components/prose/ProsePre.vue、web-admin/app/components/prose/ProseA.vue、 web-admin/app/plugins/60.mdc-prose-overrides.client.ts、web-admin/nuxt.config.ts）。
  - i18n/a11y 修复：补齐缺失的 agent.chat.*、common.scrollToBottom 等文案 key，修复 DialogContent 缺少 description 的 warning（web-admin/i18n/locales/*.json 等）。
  - 浏览器扩展导致刷新卡死兜底：忽略常见扩展 message channel 报错，并在全局 loading 出错时清理 pending，避免页面一直转圈（web-admin/app/plugins/01.unhandled- errors.client.ts、web-admin/app/plugins/global-loading.ts；文档 docs/guides/develop/web_admin_troubleshooting.md）。
  - LLM 配置优先级对齐并文档化：按 “节点 > 本次请求 > 智能体自身 > AI Settings 默认 > config 种子默认” 合成生效配置，并补充人话说明（backend/internal/ service/agent/chat_config_resolver.go、docs/guides/agent/ai_setting.md）。
  - 记住上次选中的智能体：不再默认选 agents[0]，改为持久化 last selected agentId，刷新后自动恢复（web-admin/app/composables/agent/useChatSessions.ts、web- admin/app/pages/agent/index.vue）。