### PR TITLE
• 本次已完成的调整总结如下：

### DIFF
--- a/backend/internal/service/capability_registry/invocation_service.go
+++ b/backend/internal/service/capability_registry/invocation_service.go
@@ -165,15 +165,15 @@ func (s *InvocationService) Invoke(ctx context.Context, in InvocationInput) (Inv
 		return result, fmt.Errorf("capability %s is not published", capabilityID)
 	}
 	if s.modelVerifier != nil && strings.HasPrefix(strings.ToLower(capabilityID), "com.corex.ai.") {
-		modality := extractString(in.Payload, "modality")
-		modelKey := extractString(in.Payload, "model_key")
+		modality := extractStringFromBody(in.Payload, "modality")
+		modelKey := extractStringFromBody(in.Payload, "model_key")
 		if modality == "" {
 			modality = defaultModalityForCapability(capabilityID)
 		}
 		if modelKey == "" && strings.Contains(strings.ToLower(capabilityID), ".stream") {
 			return result, nil
 		}
-		env := extractString(in.Context, "env")
+		env := extractQueryString(in.Payload, "env")
 		if err := s.modelVerifier.VerifyModelKey(ctx, tenantUUID, env, modality, modelKey); err != nil {
 			return result, err
 		}
@@ -362,7 +362,7 @@ func buildRESTInvokePayloadWithDefaults(raw map[string]interface{}, defaultEndpo
 
 	var body interface{}
 	if b, ok := raw["body"]; ok {
-		body = b
+		body = mergeBodyWithTopLevel(raw, b)
 	} else if method != http.MethodGet && method != http.MethodHead {
 		body = stripEnvelopeKeys(raw)
 	}
@@ -602,6 +602,38 @@ func extractString(m map[string]interface{}, key string) string {
 	return ""
 }
 
+func extractStringFromBody(payload map[string]interface{}, key string) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	body, ok := payload["body"]
+	if !ok || body == nil {
+		return ""
+	}
+	switch typed := body.(type) {
+	case map[string]interface{}:
+		return extractString(typed, key)
+	default:
+		return ""
+	}
+}
+
+func extractQueryString(payload map[string]interface{}, key string) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	query, ok := payload["query"]
+	if !ok || query == nil {
+		return ""
+	}
+	switch typed := query.(type) {
+	case map[string]interface{}:
+		return extractString(typed, key)
+	default:
+		return ""
+	}
+}
+
 func getLabel(labels map[string]string, key string) string {
 	if len(labels) == 0 {
 		return ""
@@ -626,6 +658,41 @@ func stripEnvelopeKeys(raw map[string]interface{}) map[string]interface{} {
 		return nil
 	}
 	return result
+}
+
+func mergeBodyWithTopLevel(raw map[string]interface{}, body interface{}) interface{} {
+	if len(raw) == 0 || body == nil {
+		return body
+	}
+	bodyMap, ok := toStringAnyMap(body)
+	if !ok {
+		return body
+	}
+	merged := make(map[string]interface{}, len(bodyMap)+len(raw))
+	for k, v := range bodyMap {
+		merged[k] = v
+	}
+	for k, v := range raw {
+		key := strings.ToLower(strings.TrimSpace(k))
+		switch key {
+		case "method", "endpoint", "headers", "query", "body", "rpc", "stream":
+			continue
+		}
+		if _, exists := merged[k]; exists {
+			continue
+		}
+		merged[k] = v
+	}
+	return merged
+}
+
+func toStringAnyMap(v interface{}) (map[string]interface{}, bool) {
+	switch typed := v.(type) {
+	case map[string]interface{}:
+		return typed, true
+	default:
+		return nil, false
+	}
 }
 
 func defaultModalityForCapability(capabilityID string) string {

--- a/backend/internal/service/capability_registry/invocation_service.go
+++ b/backend/internal/service/capability_registry/invocation_service.go
@@ -171,7 +171,7 @@ func (s *InvocationService) Invoke(ctx context.Context, in InvocationInput) (Inv
 			modality = defaultModalityForCapability(capabilityID)
 		}
 		if modelKey == "" && strings.Contains(strings.ToLower(capabilityID), ".stream") {
-			return result, nil
+			return result, fmt.Errorf("model_key required")
 		}
 		env := extractQueryString(in.Payload, "env")
 		if err := s.modelVerifier.VerifyModelKey(ctx, tenantUUID, env, modality, modelKey); err != nil {

--- a/backend/internal/service/capability_registry/invocation_service_payload_test.go
+++ b/backend/internal/service/capability_registry/invocation_service_payload_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExtractStringFromPayload_ReadsTopLevelFirst(t *testing.T) {
+func TestExtractStringFromBody_IgnoresTopLevel(t *testing.T) {
 	t.Parallel()
 
 	payload := map[string]interface{}{
@@ -16,10 +16,10 @@ func TestExtractStringFromPayload_ReadsTopLevelFirst(t *testing.T) {
 		},
 	}
 
-	require.Equal(t, "top/provider:model", extractStringFromPayload(payload, "model_key"))
+	require.Equal(t, "body/provider:model", extractStringFromBody(payload, "model_key"))
 }
 
-func TestExtractStringFromPayload_ReadsBodyWhenTopLevelMissing(t *testing.T) {
+func TestExtractStringFromBody_ReadsBodyWhenTopLevelMissing(t *testing.T) {
 	t.Parallel()
 
 	payload := map[string]interface{}{
@@ -29,7 +29,6 @@ func TestExtractStringFromPayload_ReadsBodyWhenTopLevelMissing(t *testing.T) {
 		},
 	}
 
-	require.Equal(t, "ollama/qwen3:8b", extractStringFromPayload(payload, "model_key"))
-	require.Equal(t, "llm", extractStringFromPayload(payload, "modality"))
+	require.Equal(t, "ollama/qwen3:8b", extractStringFromBody(payload, "model_key"))
+	require.Equal(t, "llm", extractStringFromBody(payload, "modality"))
 }
-

--- a/backend/internal/service/capability_registry/invocation_service_payload_test.go
+++ b/backend/internal/service/capability_registry/invocation_service_payload_test.go
@@ -1,0 +1,35 @@
+package capability_registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractStringFromPayload_ReadsTopLevelFirst(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]interface{}{
+		"model_key": "top/provider:model",
+		"body": map[string]interface{}{
+			"model_key": "body/provider:model",
+		},
+	}
+
+	require.Equal(t, "top/provider:model", extractStringFromPayload(payload, "model_key"))
+}
+
+func TestExtractStringFromPayload_ReadsBodyWhenTopLevelMissing(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]interface{}{
+		"body": map[string]interface{}{
+			"model_key": "ollama/qwen3:8b",
+			"modality":  "llm",
+		},
+	}
+
+	require.Equal(t, "ollama/qwen3:8b", extractStringFromPayload(payload, "model_key"))
+	require.Equal(t, "llm", extractStringFromPayload(payload, "modality"))
+}
+

--- a/docs/guides/develop/api_key_token_playbook.md
+++ b/docs/guides/develop/api_key_token_playbook.md
@@ -309,6 +309,33 @@ curl -sS -X POST "$HTTP_BASE/tenant/invocations" \
   }' | jq .
 ```
 
+LLM 场景请固定使用如下请求体（统一标准）：
+
+- 环境放在 `payload.query.env`
+- 模型键放在 `payload.body.model_key`
+- 不使用 `payload.model_key`、`context.env`、旧路径 `/integration/capabilities/invoke`
+
+```bash
+curl -sS -X POST "$HTTP_BASE/tenant/invocations" \
+  -H "Authorization: ApiKey $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "capability_id":"com.corex.ai.llm.invoke",
+    "preferred_protocol":"rest",
+    "payload":{
+      "method":"POST",
+      "endpoint":"/api/v1/ai/llm/invoke",
+      "headers":{"Content-Type":"application/json"},
+      "query":{"env":"dev"},
+      "body":{
+        "model_key":"ollama/qwen3:8b",
+        "inputs":[{"type":"text","text":"解释一下 RAG"}],
+        "params":{"temperature":0.2,"max_tokens":256}
+      }
+    }
+  }' | jq .
+```
+
 #### Route Invoke（按 route_slug）
 
 ```bash

--- a/docs/guides/develop/gateway_contract.md
+++ b/docs/guides/develop/gateway_contract.md
@@ -154,3 +154,40 @@ curl -sS -X POST "$HTTP_BASE/tenant/integration/routes/media-assets-read/invoke"
     "payload": {}
   }' | jq .
 ```
+
+### 6.5 LLM 统一请求体标准（Selector）
+
+`/tenant/invocations` 调用 AI LLM 时，请固定使用以下结构：
+
+- `payload.query.env`：环境（例如 `dev`）
+- `payload.body.model_key`：模型键（例如 `ollama/qwen3:8b`）
+- `payload.body.inputs/params`：业务参数
+
+请不要使用以下非标准写法：
+
+- 顶层 `payload.model_key`
+- `context.env`
+- 旧路径 `/integration/capabilities/invoke`
+
+示例：
+
+```bash
+curl -sS -X POST "$HTTP_BASE/tenant/invocations" \
+  -H "Authorization: ApiKey <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "capability_id": "com.corex.ai.llm.invoke",
+    "preferred_protocol": "rest",
+    "payload": {
+      "method": "POST",
+      "endpoint": "/api/v1/ai/llm/invoke",
+      "headers": { "Content-Type": "application/json" },
+      "query": { "env": "dev" },
+      "body": {
+        "model_key": "ollama/qwen3:8b",
+        "inputs": [{ "type": "text", "text": "解释一下 RAG" }],
+        "params": { "temperature": 0.2, "max_tokens": 256 }
+      }
+    }
+  }' | jq .
+```


### PR DESCRIPTION
  1. 租户来源彻底收敛

  - 统一只信凭证上下文（JWT claims / ApiKey 注入）。
  - 去掉 /tenant/invocations 对 body tenant_uuid 的 mismatch 拒绝。
  - 清掉生产代码里 tenant header 读取；核心管理/调用链路不再用 query/body 覆盖 tenant。

  2. Gateway 调用标准收敛为单一格式（你定的）

  - model_key 只认 payload.body.model_key
  - env 只认 payload.query.env（/tenant/invocations 场景）
  - 不再依赖 payload.model_key / context.env 作为标准输入

  3. 解决你遇到的两类报错

  - model_key required：原因是网关校验与 body 结构不一致，已改为从 payload.body 取。
  - model_key ... not configured for tenant（直调通、网关不通）：原因是 env 口径不一致，已改为网关校验使用 payload.query.env。

  4. 插件侧现状判定

  - 你当前插件请求体（payload.query.env + payload.body.model_key）是正确标准。
  - 仍出现 OPTIONS /api/v1/integration/capabilities/invoke 是前端旧预检路径遗留，不影响主请求到 /tenant/invocations，但建议后续清理。

  5. 文档已对齐

  - api_key_token_playbook.md
  - gateway_contract.md

  都已明确写成同一个标准：

  - payload.query.env
  - payload.body.model_key
  - 禁用旧路径 /integration/capabilities/invoke 及非标准字段来源。