### PR TITLE
新增测试

### DIFF
--- a/backend/internal/service/knowledge_space/ingestion_service.go
+++ b/backend/internal/service/knowledge_space/ingestion_service.go
@@ -495,6 +495,7 @@ func (s *IngestionService) TriggerAsync(ctx context.Context, in TriggerIngestion
 			bundle:              bundle,
 			format:              format,
 			sourceURI:           in.SourceURI,
+			docUUID:             in.DocUUID,
 			ingestionProfile:    in.IngestionProfile,
 			processorProfile:    in.ProcessorProfile,
 			ocrRequired:         in.OCRRequired,

--- a/backend/internal/transport/http/admin/agent/share_handlers.go
+++ b/backend/internal/transport/http/admin/agent/share_handlers.go
@@ -35,6 +35,9 @@ func (h *ShareHandler) CreateShare(c *gin.Context) {
 	if agentIDStr == "" {
 		agentIDStr = c.Param("id")
 	}
+	if agentIDStr == "" {
+		agentIDStr = c.Param("uuid")
+	}
 	agentID, err := uuid.Parse(agentIDStr)
 	if err != nil {
 		dto.ResponseError(c, nethttp.StatusBadRequest, "invalid agent_id", err)

--- a/backend/internal/transport/http/admin/agent/share_handlers_test.go
+++ b/backend/internal/transport/http/admin/agent/share_handlers_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ArtisanCloud/PowerX/internal/service/agent_lifecycle"
+	"github.com/gin-gonic/gin"
+)
+
+func TestCreateShareAcceptsUUIDRouteParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+	c.Params = gin.Params{{Key: "uuid", Value: "123e4567-e89b-42d3-a456-426614174000"}}
+
+	h := &ShareHandler{service: &agent_lifecycle.Service{}}
+	h.CreateShare(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if msg, _ := resp["message"].(string); msg != "参数验证失败" {
+		t.Fatalf("expected validation error, got message=%q", msg)
+	}
+}

--- a/backend/internal/transport/http/admin/knowledge_space/ingestion_handlers.go
+++ b/backend/internal/transport/http/admin/knowledge_space/ingestion_handlers.go
@@ -1,6 +1,7 @@
 package knowledge_space
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -687,6 +688,12 @@ func (h *IngestionHandler) UpdateChunk(c *gin.Context) {
 	}
 
 	// 更新向量索引（仅该 chunk）
+	dim, err := h.activeVectorDimensions(c.Request.Context(), spaceID)
+	if err != nil {
+		dto.ResponseError(c, http.StatusInternalServerError, "未找到可用的向量索引维度", err)
+		return
+	}
+
 	meta := make(map[string]any, len(chunkMeta)+2)
 	for k, v := range chunkMeta {
 		meta[k] = v
@@ -695,7 +702,7 @@ func (h *IngestionHandler) UpdateChunk(c *gin.Context) {
 	meta["content_hash"] = ksvc.ContentHash(content)
 	if err := h.vs.Upsert(c.Request.Context(), spaceID, []vectorstore.VectorRecord{{
 		ChunkID:   chunkUUID,
-		Embedding: ksvc.HashEmbedding(content, 32),
+		Embedding: ksvc.HashEmbedding(content, dim),
 		Metadata:  meta,
 	}}); err != nil {
 		dto.ResponseError(c, http.StatusInternalServerError, "更新向量索引失败", err)
@@ -729,7 +736,7 @@ func (h *IngestionHandler) UpdateChunk(c *gin.Context) {
 							if id != chunkIDStr {
 								continue
 							}
-							rec["Embedding"] = ksvc.HashEmbedding(content, 32)
+							rec["Embedding"] = ksvc.HashEmbedding(content, dim)
 							if m, ok := rec["Metadata"].(map[string]any); ok && m != nil {
 								m["content_hash"] = ksvc.ContentHash(content)
 								m["edited_at"] = now
@@ -771,6 +778,23 @@ func (h *IngestionHandler) UpdateChunk(c *gin.Context) {
 		"spaceId":   spaceID.String(),
 		"updatedAt": now,
 	})
+}
+
+func (h *IngestionHandler) activeVectorDimensions(ctx context.Context, spaceID uuid.UUID) (int, error) {
+	if h == nil || h.db == nil {
+		return 0, errors.New("db not initialized")
+	}
+	rec, err := knowledgeRepo.NewKnowledgeVectorIndexRepository(h.db).FindActiveBySpace(ctx, spaceID)
+	if err != nil {
+		return 0, err
+	}
+	if rec == nil {
+		return 0, errors.New("active vector index not found")
+	}
+	if rec.Dimensions <= 0 {
+		return 0, fmt.Errorf("invalid active vector index dimensions: %d", rec.Dimensions)
+	}
+	return rec.Dimensions, nil
 }
 
 func (h *IngestionHandler) PageImage(c *gin.Context) {

--- a/backend/internal/transport/http/admin/knowledge_space/ingestion_handlers_test.go
+++ b/backend/internal/transport/http/admin/knowledge_space/ingestion_handlers_test.go
@@ -1,0 +1,68 @@
+package knowledge_space
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	knowledgeModel "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/model/knowledge"
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestActiveVectorDimensionsUsesActiveIndexRecord(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite failed: %v", err)
+	}
+
+	if err := db.Exec(`ATTACH DATABASE ':memory:' AS public`).Error; err != nil {
+		t.Fatalf("attach public schema failed: %v", err)
+	}
+	if err := db.Exec(`
+CREATE TABLE public.knowledge_vector_indexes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  space_uuid TEXT,
+  index_key TEXT,
+  table_name TEXT,
+  dimensions INTEGER,
+  embedding_provider TEXT,
+  embedding_model TEXT,
+  embedding_profile_ref TEXT,
+  status TEXT,
+  last_used_at DATETIME,
+  last_error TEXT,
+  created_at DATETIME,
+  updated_at DATETIME,
+  deleted_at DATETIME
+)`).Error; err != nil {
+		t.Fatalf("create table failed: %v", err)
+	}
+
+	spaceID := uuid.New()
+	now := time.Now()
+	rec := knowledgeModel.KnowledgeVectorIndex{
+		SpaceUUID:         spaceID,
+		IndexKey:          "idx-active",
+		VectorTable:       "knowledge_vectors_1536",
+		Dimensions:        1536,
+		EmbeddingProvider: "openai",
+		EmbeddingModel:    "text-embedding-3-small",
+		Status:            knowledgeModel.KnowledgeVectorIndexStatusActive,
+	}
+	rec.CreatedAt = now
+	rec.UpdatedAt = now
+	if err := db.Table("public.knowledge_vector_indexes").Create(&rec).Error; err != nil {
+		t.Fatalf("insert active index failed: %v", err)
+	}
+
+	h := &IngestionHandler{db: db}
+	dim, err := h.activeVectorDimensions(context.Background(), spaceID)
+	if err != nil {
+		t.Fatalf("activeVectorDimensions returned error: %v", err)
+	}
+	if dim != 1536 {
+		t.Fatalf("expected dim=1536, got %d", dim)
+	}
+}


### PR DESCRIPTION
  1. CreateShare 覆盖 uuid 路由参数

  - 文件：share_handlers_test.go
  - 用例：TestCreateShareAcceptsUUIDRouteParam
  - 断言：当只传 :uuid 时，不会走 invalid agent_id，而是进入请求体校验（返回“参数验证失败”）。

  2. UpdateChunk 维度来源于 active index

  - 文件：ingestion_handlers_test.go
  - 用例：TestActiveVectorDimensionsUsesActiveIndexRecord
  - 断言：activeVectorDimensions 从 knowledge_vector_indexes 的 active 记录读取维度（示例为 1536），不是硬编码值。

  验证结果

  - go test ./internal/transport/http/admin/agent ./internal/transport/http/admin/knowledge_space -count=1 已通过。

## Summary

- [ ] 简述本次改动目标与范围

## Changes

- [ ] 列出核心改动点（代码/文档/配置）

## Verification

- [ ] 本地验证步骤已执行（请附关键命令/结果）

## WS/TaskBus Contract Checklist（必填）

- [ ] 本次是否涉及 WS/TaskBus（topic、publish/register、envelope、鉴权、tenant/trace）？
- [ ] 若涉及，是否同步更新主契约：`specs/004-eventbus-message-fabric/spec.md`
- [ ] 若涉及 WS 传输，是否同步更新：`specs/023-websocket-notify/spec.md` 与 `specs/023-websocket-notify/contracts/http-openapi.yaml`
- [ ] 是否运行一致性检查：`bash scripts/specs/check_ws_taskbus_contracts.sh`

## Risks

- [ ] 已评估兼容性/回滚影响

