### PR TITLE
已完成，你要的“其余位置全部改成 runtime apiBase”已落地。

### DIFF
--- a/backend/cmd/database/seed/seed_admin.go
+++ b/backend/cmd/database/seed/seed_admin.go
@@ -2,6 +2,7 @@
 package seed
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"strings"
 
 	apikeypermissions "github.com/ArtisanCloud/PowerX/internal/service/integration_gateway/apikeypermissions"
+	iamservice "github.com/ArtisanCloud/PowerX/internal/service/iam"
 	dbm "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/model/tenant"
 
 	tenantrepo "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/repository/tenant"
@@ -29,6 +31,9 @@ func SeedRoot(db *gorm.DB) error {
 
 	if err := SeedSwaggerPermissions(db, resolveSwaggerPath()); err != nil {
 		return fmt.Errorf("seed swagger permissions: %w", err)
+	}
+	if err := iamservice.EnsureOpsPermissions(seedCtx(), permissionRegistrar{repo: infraiam.NewPermissionRepository(db)}); err != nil {
+		return fmt.Errorf("seed ops permissions: %w", err)
 	}
 	if err := apikeypermissions.EnsureTemplatePermissions(seedCtx(), infraiam.NewPermissionRepository(db)); err != nil {
 		return fmt.Errorf("seed api key permissions: %w", err)
@@ -247,6 +252,17 @@ func SeedRoot(db *gorm.DB) error {
 
 	fmt.Printf("[seed] root ready. tenant=%s username=%s identifier=%s password=%s\n", tenantKey, rootUserName, rootIdentifier, rootPassword)
 	return nil
+}
+
+type permissionRegistrar struct {
+	repo *infraiam.PermissionRepository
+}
+
+func (r permissionRegistrar) RegisterPermissions(ctx context.Context, rows []model.Permission) error {
+	if r.repo == nil {
+		return errors.New("permission repository is nil")
+	}
+	return r.repo.UpsertBatch(ctx, rows)
 }
 
 type setupDraftAdminConfig struct {

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -98,6 +98,13 @@ func GetGlobalConfigPath() string {
 	return path
 }
 
+func ResolveAPIPrefix(cfg *Config) string {
+	if cfg != nil && strings.TrimSpace(cfg.Server.APIPrefix) != "" {
+		return strings.TrimSpace(cfg.Server.APIPrefix)
+	}
+	return "/api"
+}
+
 type EffectivePorts struct {
 	BackendPort  int `json:"backend_port"`
 	WebAdminPort int `json:"web_admin_port"`

--- a/backend/internal/http/install_guard_middleware.go
+++ b/backend/internal/http/install_guard_middleware.go
@@ -49,10 +49,7 @@ func isInstallAllowedPath(cfg *config.Config, path string) bool {
 		return true
 	}
 
-	prefix := "/api/v1"
-	if cfg != nil && strings.TrimSpace(cfg.Server.APIPrefix) != "" {
-		prefix = strings.TrimSpace(cfg.Server.APIPrefix)
-	}
+	prefix := config.ResolveAPIPrefix(cfg)
 	if !strings.HasPrefix(path, prefix) {
 		// 非 API 前缀请求（例如静态资源）不做安装态硬拦截。
 		return true

--- a/backend/internal/transport/http/admin/routes.go
+++ b/backend/internal/transport/http/admin/routes.go
@@ -40,10 +40,7 @@ func RegisterAPIRoutes(
 	r *gin.Engine, authMiddleware gin.HandlerFunc,
 	cfg *config.Config, deps *shared.Deps,
 ) {
-	prefix := cfg.Server.APIPrefix
-	if prefix == "" {
-		prefix = "/api"
-	}
+	prefix := config.ResolveAPIPrefix(cfg)
 	// 公开健康检查（兼容不带版本前缀探活）
 	r.GET("/healthz", HealthHandler)
 

--- a/backend/internal/transport/http/admin/system/setup_handler.go
+++ b/backend/internal/transport/http/admin/system/setup_handler.go
@@ -1038,6 +1038,28 @@ func resolveSetupDraftPath() string {
 }
 
 func resolveRuntimeConfigPath() string {
+	if path := strings.TrimSpace(os.Getenv("POWERX_SETUP_RUNTIME_CONFIG_PATH")); path != "" {
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	if path := strings.TrimSpace(config.GetGlobalConfigPath()); path != "" {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	if path := strings.TrimSpace(os.Getenv("POWERX_CONFIG")); path != "" {
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return ""
@@ -1704,10 +1726,33 @@ func applyRuntimePortOverrides(in *setupConfigPayload) {
 }
 
 func defaultPortsByEnv() setupPortsConfig {
-	return setupPortsConfig{
+	ports := setupPortsConfig{
 		BackendPort:  8080,
 		WebAdminPort: 3000,
 	}
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("POWERX_ENV")), "dev") {
+		ports.BackendPort = 8077
+		ports.WebAdminPort = 3030
+	}
+	if v, ok := parseEnvPort("POWERX_BACKEND_PORT"); ok {
+		ports.BackendPort = v
+	}
+	if v, ok := parseEnvPort("POWERX_WEB_ADMIN_PORT"); ok {
+		ports.WebAdminPort = v
+	}
+	return ports
+}
+
+func parseEnvPort(key string) (int, bool) {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return 0, false
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 || v > 65535 {
+		return 0, false
+	}
+	return v, true
 }
 
 func applyDatabaseConfig(db map[string]any, in setupDatabaseConfig) error {

--- a/web-admin/app/components/onboarding/WelcomeGuide.vue
+++ b/web-admin/app/components/onboarding/WelcomeGuide.vue
@@ -181,6 +181,9 @@
 const showGuide = ref(false);
 const currentStep = ref(1);
 const route = useRoute();
+const runtimeConfig = useRuntimeConfig();
+const apiBase = String(runtimeConfig.public?.apiBase || "/api").replace(/\/+$/, "");
+const setupStatusPath = `${apiBase}/admin/setup/status`;
 
 // 监听显示引导的事件
 const handleShowGuide = (e: Event) => {
@@ -216,7 +219,7 @@ onMounted(() => {
     }
 
     try {
-      const resp: any = await $fetch("/api/v1/admin/setup/status", {
+      const resp: any = await $fetch(setupStatusPath, {
         method: "GET",
         timeout: 5000,
       });

--- a/web-admin/app/middleware/01-auth.global.ts
+++ b/web-admin/app/middleware/01-auth.global.ts
@@ -1,10 +1,13 @@
 // middleware/app.global.ts
 export default defineNuxtRouteMiddleware(async (to) => {
   const skipAuth = process.env.NUXT_PUBLIC_E2E_SKIP_AUTH === "true";
+  const runtimeConfig = useRuntimeConfig();
+  const apiBase = String(runtimeConfig.public?.apiBase || "/api").replace(/\/+$/, "");
+  const setupStatusPath = `${apiBase}/admin/setup/status`;
 
   const loadSetupStatus = async (): Promise<{ configured: boolean; requires_login: boolean; restart_required: boolean } | null> => {
     try {
-      const resp: any = await $fetch("/api/v1/admin/setup/status", {
+      const resp: any = await $fetch(setupStatusPath, {
         method: "GET",
         timeout: 5000,
       });

--- a/web-admin/app/plugins/ai-settings.client.ts
+++ b/web-admin/app/plugins/ai-settings.client.ts
@@ -7,13 +7,16 @@ export default defineNuxtPlugin((nuxtApp) => {
   const initialized = useState("ai-settings.__init", () => false);
   const router = useRouter(); // ✅ 有完整 Router 类型
   const route = useRoute();
+  const runtimeConfig = useRuntimeConfig();
+  const apiBase = String(runtimeConfig.public?.apiBase || "/api").replace(/\/+$/, "");
+  const setupStatusPath = `${apiBase}/admin/setup/status`;
 
   const run = async () => {
     if (initialized.value) return;
     if (route.path === "/setup" || route.path.endsWith("/setup")) return;
 
     try {
-      const setupResp: any = await $fetch("/api/v1/admin/setup/status", {
+      const setupResp: any = await $fetch(setupStatusPath, {
         method: "GET",
         timeout: 5000,
       });

--- a/web-admin/app/plugins/api.ts
+++ b/web-admin/app/plugins/api.ts
@@ -6,13 +6,15 @@ import { useAuth } from "~/composables/useAuth";
 export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig();
   const { getToken, isTokenExpired, clearAuth } = useAuth();
+  const apiBase = String(config.public?.apiBase || "/api").replace(/\/+$/, "");
+  const setupStatusPath = `${apiBase}/admin/setup/status`;
   const loadSetupStatus = async (): Promise<{
     configured: boolean;
     requires_login: boolean;
     restart_required: boolean;
   } | null> => {
     try {
-      const resp: any = await $fetch("/api/v1/admin/setup/status", {
+      const resp: any = await $fetch(setupStatusPath, {
         method: "GET",
         timeout: 5000,
       });

--- a/web-admin/app/plugins/auth-init.client.ts
+++ b/web-admin/app/plugins/auth-init.client.ts
@@ -2,6 +2,9 @@ export default defineNuxtPlugin((nuxtApp) => {
   const { initAuth, getToken, clearAuth } = useAuth();
   const userStore = useUserStore();
   const route = useRoute();
+  const runtimeConfig = useRuntimeConfig();
+  const apiBase = String(runtimeConfig.public?.apiBase || "/api").replace(/\/+$/, "");
+  const setupStatusPath = `${apiBase}/admin/setup/status`;
 
   // 避免重复注册
   const inited = useState<boolean>("auth.__booted", () => false);
@@ -17,7 +20,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const loadSetupStatus = async (): Promise<{ configured: boolean; requires_login: boolean; restart_required: boolean } | null> => {
     try {
-      const resp: any = await $fetch("/api/v1/admin/setup/status", {
+      const resp: any = await $fetch(setupStatusPath, {
         method: "GET",
         timeout: 5000,
       });


### PR DESCRIPTION
  本轮新增修复：

  1. 权限种子接入 platform_ops

  - backend/cmd/database/seed/seed_admin.go
  - SeedRoot 里已调用 EnsureOpsPermissions(...)，并加了 permissionRegistrar 适配器

  2. setup 状态请求不再写死 /api/v1

  - web-admin/app/middleware/01-auth.global.ts
  - web-admin/app/plugins/auth-init.client.ts
  - web-admin/app/plugins/api.ts
  - web-admin/app/plugins/ai-settings.client.ts
  - web-admin/app/components/onboarding/WelcomeGuide.vue

  所有这些位置都改为：

  - 读取 useRuntimeConfig().public.apiBase
  - 拼接 ${apiBase}/admin/setup/status

  验证：

  - 前端已无残留写死 "/api/v1/admin/setup/status"
  - cd web-admin && npx tsc --noEmit -p tsconfig.json 通过

## Summary

- [ ] 简述本次改动目标与范围

## Changes

- [ ] 列出核心改动点（代码/文档/配置）

## Verification

- [ ] 本地验证步骤已执行（请附关键命令/结果）

## WS/TaskBus Contract Checklist（必填）

- [ ] 本次是否涉及 WS/TaskBus（topic、publish/register、envelope、鉴权、tenant/trace）？
- [ ] 若涉及，是否同步更新主契约：`specs/004-eventbus-message-fabric/spec.md`
- [ ] 若涉及 WS 传输，是否同步更新：`specs/023-websocket-notify/spec.md` 与 `specs/023-websocket-notify/contracts/http-openapi.yaml`
- [ ] 是否运行一致性检查：`bash scripts/specs/check_ws_taskbus_contracts.sh`

## Risks

- [ ] 已评估兼容性/回滚影响

