### PR TITLE
已完成修改并做了脚本语法检查（bash -n 通过）。下面我给你一个精简结果：改了哪些文件、现在如何按 tag 发布切换、你下一步直接执行…

### DIFF
--- a/backend/scripts/ops/switch-release-systemd.sh
+++ b/backend/scripts/ops/switch-release-systemd.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage:
+  $0 <target_tag_or_version> [--with-runner] [--timeout-sec N]
+
+Description:
+  Switch /opt/powerx symlinks to /opt/powerx/releases/<target_tag_or_version>,
+  restart systemd services, and run backend health check.
+  If health check fails, auto rollback to previous symlink targets.
+  Production should use immutable git tag names (e.g. v2.0.2).
+
+Options:
+  --with-runner            Also switch/restart powerx-runner.
+  --timeout-sec N          Health check timeout seconds (default: 90).
+
+Environment overrides:
+  POWERX_RELEASES_ROOT     Default: /opt/powerx/releases
+  POWERX_LINKS_ROOT        Default: /opt/powerx
+  POWERX_HEALTH_URL        Default: http://127.0.0.1:8080/api/v1/health
+  POWERX_HEALTH_EXPECT     Default: 200
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+TARGET_REF="$1"
+shift
+
+WITH_RUNNER=0
+TIMEOUT_SEC=90
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-runner)
+      WITH_RUNNER=1
+      shift
+      ;;
+    --timeout-sec)
+      TIMEOUT_SEC="${2:-}"
+      if [[ -z "$TIMEOUT_SEC" ]]; then
+        echo "[switch-release] --timeout-sec requires a value" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[switch-release] unknown arg: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+RELEASES_ROOT="${POWERX_RELEASES_ROOT:-/opt/powerx/releases}"
+LINKS_ROOT="${POWERX_LINKS_ROOT:-/opt/powerx}"
+HEALTH_URL="${POWERX_HEALTH_URL:-http://127.0.0.1:8080/api/v1/health}"
+HEALTH_EXPECT="${POWERX_HEALTH_EXPECT:-200}"
+
+TARGET_ROOT="${RELEASES_ROOT}/${TARGET_REF}"
+TARGET_BACKEND="${TARGET_ROOT}/backend"
+TARGET_WEB_ADMIN="${TARGET_ROOT}/web-admin"
+TARGET_RUNNER="${TARGET_ROOT}/runner"
+
+LINK_BACKEND="${LINKS_ROOT}/backend"
+LINK_WEB_ADMIN="${LINKS_ROOT}/web-admin"
+LINK_RUNNER="${LINKS_ROOT}/runner"
+
+if [[ ! -d "$TARGET_BACKEND" ]]; then
+  echo "[switch-release] missing target backend dir: $TARGET_BACKEND" >&2
+  exit 1
+fi
+if [[ ! -d "$TARGET_WEB_ADMIN" ]]; then
+  echo "[switch-release] missing target web-admin dir: $TARGET_WEB_ADMIN" >&2
+  exit 1
+fi
+if [[ "$WITH_RUNNER" == "1" && ! -d "$TARGET_RUNNER" ]]; then
+  echo "[switch-release] missing target runner dir: $TARGET_RUNNER" >&2
+  exit 1
+fi
+
+PREV_BACKEND=""
+PREV_WEB_ADMIN=""
+PREV_RUNNER=""
+
+if [[ -L "$LINK_BACKEND" ]]; then
+  PREV_BACKEND="$(readlink "$LINK_BACKEND")"
+fi
+if [[ -L "$LINK_WEB_ADMIN" ]]; then
+  PREV_WEB_ADMIN="$(readlink "$LINK_WEB_ADMIN")"
+fi
+if [[ "$WITH_RUNNER" == "1" && -L "$LINK_RUNNER" ]]; then
+  PREV_RUNNER="$(readlink "$LINK_RUNNER")"
+fi
+
+echo "[switch-release] target ref: $TARGET_REF"
+echo "[switch-release] releases root: $RELEASES_ROOT"
+echo "[switch-release] links root: $LINKS_ROOT"
+
+rollback() {
+  echo "[switch-release] rollback start"
+  if [[ -n "$PREV_BACKEND" ]]; then
+    ln -sfn "$PREV_BACKEND" "$LINK_BACKEND"
+  fi
+  if [[ -n "$PREV_WEB_ADMIN" ]]; then
+    ln -sfn "$PREV_WEB_ADMIN" "$LINK_WEB_ADMIN"
+  fi
+  if [[ "$WITH_RUNNER" == "1" && -n "$PREV_RUNNER" ]]; then
+    ln -sfn "$PREV_RUNNER" "$LINK_RUNNER"
+  fi
+
+  systemctl daemon-reload
+  systemctl restart powerx-backend powerx-web-admin
+  if [[ "$WITH_RUNNER" == "1" ]]; then
+    systemctl restart powerx-runner
+  fi
+  echo "[switch-release] rollback done"
+}
+
+trap 'echo "[switch-release] error occurred" >&2; rollback' ERR
+
+ln -sfn "$TARGET_BACKEND" "$LINK_BACKEND"
+ln -sfn "$TARGET_WEB_ADMIN" "$LINK_WEB_ADMIN"
+if [[ "$WITH_RUNNER" == "1" ]]; then
+  ln -sfn "$TARGET_RUNNER" "$LINK_RUNNER"
+fi
+
+systemctl daemon-reload
+systemctl restart powerx-backend powerx-web-admin
+if [[ "$WITH_RUNNER" == "1" ]]; then
+  systemctl restart powerx-runner
+fi
+
+START_TS="$(date +%s)"
+while true; do
+  CODE="$(curl -sS -o /tmp/powerx-switch-health.json -w '%{http_code}' "$HEALTH_URL" || true)"
+  if [[ "$CODE" == "$HEALTH_EXPECT" ]]; then
+    break
+  fi
+  NOW_TS="$(date +%s)"
+  if (( NOW_TS - START_TS >= TIMEOUT_SEC )); then
+    echo "[switch-release] health check timeout, url=$HEALTH_URL code=$CODE expect=$HEALTH_EXPECT" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+trap - ERR
+
+echo "[switch-release] success: switched to ${TARGET_REF}"
+systemctl --no-pager --full status powerx-backend powerx-web-admin | sed -n '1,40p'
+if [[ "$WITH_RUNNER" == "1" ]]; then
+  systemctl --no-pager --full status powerx-runner | sed -n '1,20p'
+fi

--- a/docs/guides/deploy/025-powerx-docker-systemd/systemd/01-prepare-artifacts.md
+++ b/docs/guides/deploy/025-powerx-docker-systemd/systemd/01-prepare-artifacts.md
@@ -6,9 +6,6 @@
 - backend 运行配置：`backend/etc/config.yaml`
 - runner Node 产物：`dist/main.js`
 - web-admin Nuxt 产物：`.output/server/index.mjs`
-- 环境变量模板：
-  - backend/runtime：`config/powerx.env`（来源：`backend/.env.example`）
-  - web-admin：`config/web-admin.env`（来源：`web-admin/.env.example`）
 
 同时支持两种方式：
 - 手工步骤（逐条执行，便于排错）
@@ -16,7 +13,7 @@
 
 ## 2. 前置条件
 - 构建机已安装 Go 1.24、Node 20、npm。
-- 已切到目标发布分支/commit。
+- 已切到目标发布 tag/commit（生产建议固定使用 tag，如 `v2.0.2`）。
 - 已规划发布目录：`/opt/powerx/releases/<version>/`。
 - 以下命令默认在仓库根目录执行。
 - Go 模块在 `backend/go.mod`，因此构建 backend 时必须先 `cd backend`（或使用 `go -C backend ...`）。
@@ -25,7 +22,7 @@
 ## 3. 构建 backend
 
 ```bash
-export VERSION=v2.0.1
+export VERSION=v2.0.2 # 推荐与 git tag 同名
 mkdir -p dist/systemd/${VERSION}/backend
 cd backend
 go build -o ../dist/systemd/${VERSION}/backend/powerx ./cmd/app
@@ -53,16 +50,14 @@ cp -R web-admin/.output dist/systemd/${VERSION}/web-admin/
 预期结果：生成 `dist/systemd/${VERSION}/web-admin/.output/server/index.mjs`。
 失败处理：检查前端环境变量与 Nuxt 构建错误。
 
-## 5. 复制配置、systemd 单元与 env 模板到 dist
+## 5. 复制配置与 systemd 单元到 dist
 
 ```bash
 mkdir -p dist/systemd/${VERSION}/backend/etc
 cp -R backend/etc/* dist/systemd/${VERSION}/backend/etc/
 
-mkdir -p dist/systemd/${VERSION}/systemd dist/systemd/${VERSION}/config
+mkdir -p dist/systemd/${VERSION}/systemd
 cp deploy/powerx/systemd/*.service dist/systemd/${VERSION}/systemd/
-cp backend/.env.example dist/systemd/${VERSION}/config/powerx.env
-cp web-admin/.env.example dist/systemd/${VERSION}/config/web-admin.env
 ```
 
 预期结果：`dist/systemd/${VERSION}` 包含可部署所需二进制、配置和 service 文件。
@@ -71,27 +66,22 @@ cp web-admin/.env.example dist/systemd/${VERSION}/config/web-admin.env
 ## 6. 调整 dist 中配置（发布前）
 
 - 编辑 `dist/systemd/${VERSION}/backend/etc/config.yaml`：数据库、缓存、对象存储、认证等。
-- 编辑 `dist/systemd/${VERSION}/config/powerx.env`（部署时复制到 `/etc/powerx/powerx.env`）。
-- `dist/systemd/${VERSION}/config/web-admin.env` 用于 web-admin 专项变量参考（如需拆分独立 EnvironmentFile 可基于此扩展）。
-- 兼容产物：同时保留 `.example` 文件，便于历史脚本继续使用。
+- 若运行期需要环境覆盖，请单独维护 `/etc/powerx/powerx.env`（不纳入 `dist` 产物）。
 
 ## 6.1 本地手动启动验证（macOS/Linux 通用）
 
-在 systemd 部署前，可先用 dist 产物里的 env 做手动验证：
+在 systemd 部署前，可先用本机环境变量做手动验证（示例值请按实际环境替换）：
 
 ```bash
 # 终端1：backend
-set -a
-source dist/systemd/${VERSION}/config/powerx.env
-set +a
+export POWERX_BACKEND_PORT=8080
 cd backend && go run ./cmd/app
 ```
 
 ```bash
 # 终端2：web-admin
-set -a
-source dist/systemd/${VERSION}/config/powerx.env
-set +a
+export POWERX_WEB_ADMIN_PORT=3000
+export POWERX_BACKEND_PORT=8080
 cd web-admin && PORT=${POWERX_WEB_ADMIN_PORT} UPSTREAM=http://127.0.0.1:${POWERX_BACKEND_PORT} npm run dev
 ```
 
@@ -104,18 +94,14 @@ cd web-admin && PORT=${POWERX_WEB_ADMIN_PORT} UPSTREAM=http://127.0.0.1:${POWERX
 ```bash
 # 终端1：backend（二进制）
 cd dist/systemd/${VERSION}/backend
-set -a
-source ../config/powerx.env
-set +a
 ./powerx
 ```
 
 ```bash
 # 终端2：web-admin（Nuxt server 产物）
 cd dist/systemd/${VERSION}
-set -a
-source ./config/powerx.env
-set +a
+export POWERX_WEB_ADMIN_PORT=3000
+export POWERX_BACKEND_PORT=8080
 PORT=${POWERX_WEB_ADMIN_PORT} \
 UPSTREAM=http://127.0.0.1:${POWERX_BACKEND_PORT} \
 node ./web-admin/.output/server/index.mjs
@@ -173,7 +159,7 @@ sudo ln -sfn /opt/powerx/releases/${VERSION}/runner /opt/powerx/runner
 示例：
 
 ```bash
-export VERSION=v2.0.1
+export VERSION=v2.0.2 # 推荐与 git tag 同名
 
 # 全量（包含 npm ci）
 make dist DIST_VERSION=$VERSION
@@ -185,7 +171,7 @@ make dist DIST_VERSION=$VERSION NPM_INSTALL=0
 产物结构示例：
 
 ```text
-dist/systemd/v2.0.1/
+dist/systemd/v2.0.2/
 ├── backend/
 │   ├── powerx
 │   ├── etc/config.yaml
@@ -195,10 +181,6 @@ dist/systemd/v2.0.1/
 │   ├── internal/server/agent/blueprints/...
 │   └── pkg/corex/flow/blueprints/...
 ├── web-admin/.output/...
-├── config/powerx.env
-├── config/web-admin.env
-├── config/powerx.env.example
-├── config/web-admin.env.example
 ├── systemd/
 │   ├── powerx-backend.service
 │   ├── powerx-runner.service
@@ -207,3 +189,8 @@ dist/systemd/v2.0.1/
 ```
 
 说明：若源码包含 `backend/runner` 且你启用了 runner 打包流程，产物中会额外出现 `runner/dist/...`。
+
+## 10. Git 分支与 Tag 建议（对齐生产发布）
+- 预发布验证：可从 `develop` 构建测试包（例如 `DIST_VERSION=dev-20260403`）。
+- 生产发布：必须从不可变 tag 构建（例如 `v2.0.2`），并保持目录名与 tag 一致。
+- 服务器切换：使用 `backend/scripts/ops/switch-release-systemd.sh <tag>` 切换软链并重启服务。

--- a/docs/guides/deploy/025-powerx-docker-systemd/systemd/02-deploy-config-start.md
+++ b/docs/guides/deploy/025-powerx-docker-systemd/systemd/02-deploy-config-start.md
@@ -7,12 +7,76 @@
 
 本地若仅做发布包自检（不启 systemd），请先按 `01-prepare-artifacts.md` 的“6.2 直接从 dist 制品启动”执行。
 
-## 2. 安装 service 文件
+## 1.1 分支与 Tag 策略（建议）
+- `develop`：仅用于预发布验证环境（staging/UAT），允许快速迭代。
+- 生产发布：使用不可变 Git tag（例如 `v2.0.2`），不要直接用分支名作为生产版本。
+- 推荐流程：
+  - 先在 `develop` 构建并验证；
+  - 验证通过后从对应提交打 tag；
+  - 从该 tag 重新构建生产包并发布；
+  - 通过软链切换（`/opt/powerx/{backend,web-admin,runner}`）完成上线与回滚。
 
+## 1.2 从 Git 拉代码并切换到 tag（推荐）
+示例（服务器本地构建）：
+
+```bash
+git clone https://github.com/ArtisanCloud/PowerX.git
+cd PowerX
+git fetch --tags --prune
+git checkout v2.0.2
+```
+
+说明：
+- `git checkout <tag>` 会进入 detached HEAD，这是预期行为。
+- 若需要临时调试，可基于 tag 建分支：`git checkout -b hotfix/v2.0.2-fix v2.0.2`。
+
+## 2. 从 GitHub 下载发布包（可选）
+若你不在服务器本地构建，可直接下载 CI/Release 产物。示例：
+
+```bash
+export VERSION=v2.0.2
+export REPO=ArtisanCloud/PowerX
+export PKG=powerx-systemd-${VERSION}.tar.gz
+
+# 需先在 GitHub Release 中上传该文件名的打包产物
+curl -fL -o "${PKG}" "https://github.com/${REPO}/releases/download/${VERSION}/${PKG}"
+
+sudo mkdir -p /opt/powerx/releases/${VERSION}
+sudo tar -xzf "${PKG}" -C /opt/powerx/releases/${VERSION}
+```
+
+预期结果：`/opt/powerx/releases/${VERSION}` 下包含 `backend/`、`web-admin/`、`systemd/` 等目录。
+
+## 3. 安装运行时依赖（目标机）
+最小依赖：
+- `systemd`（服务托管）
+- `bash`、`curl`（运维脚本/健康检查）
+- `node`（web-admin/runner 运行时）
+
+Ubuntu/Debian 示例：
+
+```bash
+sudo apt-get update
+sudo apt-get install -y systemd curl ca-certificates bash
+
+# Node.js 20（若系统未安装）
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+node -v
+```
+
+CentOS/RHEL 示例（按企业源调整）：
+
+```bash
+sudo yum install -y systemd curl ca-certificates bash
+# Node.js 20 建议使用企业镜像或 NodeSource/RPM 源安装
+```
+
+## 4. 安装 service 文件
 先约定发布版本变量（示例）：
 
 ```bash
-export VERSION=v2.0.1
+export VERSION=v2.0.2
 ```
 
 从 dist 产物安装 service：
@@ -25,14 +89,18 @@ sudo systemctl daemon-reload
 预期结果：`systemctl list-unit-files | rg 'powerx-(backend|web-admin|runner)'` 可见 unit 文件。
 失败处理：检查文件权限与语法。
 
-## 3. 配置环境变量文件
+## 5. 配置环境变量文件（可选）
+`make dist` 不产出 `.env`；运行期如需覆盖配置，可使用 `/etc/powerx/powerx.env`。
+若不需要环境覆盖，可跳过本节，仅使用 `config.yaml`。
 
-service 文件默认读取：`/etc/powerx/powerx.env`。  
-建议从 dist 产物模板复制：
+示例（手工创建）：
 
 ```bash
 sudo mkdir -p /etc/powerx
-sudo cp dist/systemd/${VERSION}/config/powerx.env /etc/powerx/powerx.env
+sudo tee /etc/powerx/powerx.env >/dev/null <<'EOF_ENV'
+POWERX_BACKEND_PORT=8080
+POWERX_WEB_ADMIN_PORT=3000
+EOF_ENV
 ```
 
 预期结果：`/etc/powerx/powerx.env` 存在且可读，且已按环境改成真实值。
@@ -41,9 +109,8 @@ sudo cp dist/systemd/${VERSION}/config/powerx.env /etc/powerx/powerx.env
 部署前务必先完成必须配置项核对：`../00-required-config.md`。
 
 补充：
-- `dist/systemd/${VERSION}/config/web-admin.env` 提供 web-admin 专项变量模板。
 - 当前默认 service 统一读取 `/etc/powerx/powerx.env`；若你希望 web-admin 独立变量文件，可在 `powerx-web-admin.service` 增加或替换 `EnvironmentFile`。
-- 兼容说明：`dist/.../config/*.env.example` 仍保留，供历史流程兼容。
+- 建议仅保留少量“实例级”覆盖项到 env 文件（端口、上游地址等），业务配置放在 `config.yaml`。
 
 端口策略说明：
 - `POWERX_ENV=prod` 默认推荐 `web-admin=3000`、`backend=8080`
@@ -51,7 +118,14 @@ sudo cp dist/systemd/${VERSION}/config/powerx.env /etc/powerx/powerx.env
 - gRPC 端口通过 `POWERX_GRPC_PORT` 控制（prod 默认 `9010`，dev 默认 `9001`）
 - 实际监听端口以 `/etc/powerx/powerx.env` 中 `POWERX_WEB_ADMIN_PORT`、`POWERX_BACKEND_PORT`、`POWERX_GRPC_PORT` 为准（有值即覆盖默认）
 
-## 4. 校验 service 路径与制品一致
+## 5.1 配置优先级与追溯
+- 优先级：`EnvironmentFile(/etc/powerx/powerx.env)` > `backend/etc/config.yaml`
+- 发布追溯最小集合：
+  - `dist/systemd/${VERSION}/manifest.txt`
+  - `/opt/powerx/backend/etc/config.yaml`（或软链目标）
+  - `/etc/powerx/powerx.env`（若启用）
+
+## 6. 校验 service 路径与制品一致
 基础服务必查两项：
 - `powerx-backend.service` 的 `ExecStart=/opt/powerx/backend/powerx`
 - `powerx-web-admin.service` 的 `ExecStart=/usr/bin/node /opt/powerx/web-admin/.output/server/index.mjs`
@@ -61,8 +135,7 @@ sudo cp dist/systemd/${VERSION}/config/powerx.env /etc/powerx/powerx.env
 
 若你的目录不同，先改 service 文件再 reload。
 
-## 5. 启动并设置自启
-
+## 7. 启动并设置自启
 先启动基础双服务（backend + web-admin）：
 
 ```bash
@@ -82,11 +155,20 @@ sudo systemctl restart powerx-runner
 sudo systemctl status powerx-runner --no-pager
 ```
 
-## 6. 首次安装引导配置页（推荐）
+## 7.1 使用脚本按 tag 切换版本（推荐）
+当 `/opt/powerx/releases/<tag>` 已存在时，使用脚本切换：
 
-启动后访问 `http://<host>:<port>/setup` 完成首次安装引导。  
+```bash
+sudo bash backend/scripts/ops/switch-release-systemd.sh v2.0.2 --with-runner
+```
+
+说明：
+- 脚本会自动切换软链、重启服务、执行健康检查。
+- 健康检查失败会自动回滚到切换前的软链目标。
+
+## 8. 首次安装引导配置页（推荐）
+启动后访问 `http://<host>:<port>/setup` 完成首次安装引导。
 完整步骤、字段含义、接口说明与排障，请统一参考：`../setup.md`。
 
-## 7. 引导页排障
-
+## 9. 引导页排障
 排障条目已收敛到 `../setup.md`，本节仅保留索引，避免重复维护。

--- a/docs/guides/deploy/025-powerx-docker-systemd/systemd/03-verify-and-rollback.md
+++ b/docs/guides/deploy/025-powerx-docker-systemd/systemd/03-verify-and-rollback.md
@@ -78,6 +78,12 @@ sudo systemctl restart powerx-runner
 
 3. 再做健康验收。
 
+推荐：使用切换脚本执行带健康检查的回切（tag 示例）：
+
+```bash
+sudo bash backend/scripts/ops/switch-release-systemd.sh v2.0.1 --with-runner
+```
+
 ## 5. 回滚成功判定
 - `/api/v1/health` 返回 200。
 - 管理端关键页面可访问。

--- a/docs/guides/deploy/025-powerx-docker-systemd/systemd/README.md
+++ b/docs/guides/deploy/025-powerx-docker-systemd/systemd/README.md
@@ -1,6 +1,7 @@
 # systemd 部署文档索引（025）
 
 本目录提供 PowerX systemd 生产部署分步手册，按“先准备制品，再部署启动”组织。
+默认发布基准为 Git tag（例如 `v2.0.2`），`develop` 仅用于预发布验证。
 
 ## 文档列表
 - `../00-required-config.md`：部署前必须配置项总清单（强烈建议先核对）。
@@ -17,7 +18,17 @@
   - `make dist DIST_VERSION=$VERSION`
   - `make dist DIST_VERSION=$VERSION NPM_INSTALL=0`（跳过 `npm ci`，仅构建）
 
+## 配置规范（可追溯）
+- 规则 R1（构建期）：`make dist` 不依赖 `.env` 文件，发布制品以 `backend/etc/config.yaml` 为主配置来源。
+- 规则 R2（运行期）：systemd 可选通过 `EnvironmentFile=/etc/powerx/powerx.env` 覆盖少量运行参数；该文件不参与构建产物签名与版本化。
+- 规则 R3（审计）：生产变更必须同时记录：
+  - 发布版本：`dist/systemd/<version>/manifest.txt`
+  - 运行配置：`/opt/powerx/backend/etc/config.yaml`（或软链目标）
+  - 环境覆盖（若启用）：`/etc/powerx/powerx.env`
+- 规则 R4（优先级）：同一项配置冲突时，进程环境变量优先于 `config.yaml`。
+
 ## 对应资产
 - systemd 单元文件：`deploy/powerx/systemd/{powerx-backend.service,powerx-runner.service,powerx-web-admin.service}`
 - 健康检查脚本：`backend/scripts/ops/deploy-check.sh`
+- 软链切换脚本：`backend/scripts/ops/switch-release-systemd.sh`
 - API 回滚脚本：`backend/scripts/ops/rollback-release.sh`


### PR DESCRIPTION
…什么命令。

• 已对齐完成，核心是“生产按 tag 切换”，脚本和文档一致了。

  变更文件：

  - backend/scripts/ops/switch-release-systemd.sh
  - docs/guides/deploy/025-powerx-docker-systemd/systemd/README.md
  - docs/guides/deploy/025-powerx-docker-systemd/systemd/01-prepare-artifacts.md
  - docs/guides/deploy/025-powerx-docker-systemd/systemd/02-deploy-config-start.md
  - docs/guides/deploy/025-powerx-docker-systemd/systemd/03-verify-and-rollback.md

  你关心的对齐点：

  - 脚本参数语义改为 target_tag_or_version，日志也改成 target ref，并明确生产建议用不可变 tag。
  - 文档新增并统一：
      - develop 仅预发验证；
      - 生产必须从 tag 构建； - 服务器上 git fetch --tags + git checkout <tag>； - 用 switch-release-systemd.sh <tag> 做软链切换 + 健康检查 + 失败自动回滚。

  你现在可直接用：

  1. 构建/发布目录名按 tag：v2.0.2
  2. 切换命令：

  sudo bash backend/scripts/ops/switch-release-systemd.sh v2.0.2 --with-runner

  补充：

  - 脚本语法检查已过：bash -n backend/scripts/ops/switch-release-systemd.sh。

## Summary

- [ ] 简述本次改动目标与范围

## Changes

- [ ] 列出核心改动点（代码/文档/配置）

## Verification

- [ ] 本地验证步骤已执行（请附关键命令/结果）

## WS/TaskBus Contract Checklist（必填）

- [ ] 本次是否涉及 WS/TaskBus（topic、publish/register、envelope、鉴权、tenant/trace）？
- [ ] 若涉及，是否同步更新主契约：`specs/004-eventbus-message-fabric/spec.md`
- [ ] 若涉及 WS 传输，是否同步更新：`specs/023-websocket-notify/spec.md` 与 `specs/023-websocket-notify/contracts/http-openapi.yaml`
- [ ] 是否运行一致性检查：`bash scripts/specs/check_ws_taskbus_contracts.sh`

## Risks

- [ ] 已评估兼容性/回滚影响

