### PR TITLE
 1. docs/guides/deploy/025-powerx-docker-systemd/systemd-dev/01-deplo…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-05
 - PostgreSQL（IAM 用户/成员/角色数据）、Redis（会话与缓存） (026-iam)
 - Go 1.24（backend）, TypeScript + Nuxt 4（web-admin） + Gin HTTP, GORM, PostgreSQL, Redis, systemd/ops scripts, Nuxt UI (027-monitor-center)
 - PostgreSQL（策略/作业/演练/告警元数据）+ 文件或对象存储（备份产物） (027-monitor-center)
+- Go 1.24 for backend/CoreX services and CLIs; TypeScript with Nuxt 4/Vue 3 for Web Admin; Buf toolchain for gRPC contracts. + Gin HTTP stack, GORM, PostgreSQL JSONB, Redis only if later used for read caches, google.golang.org/grpc, Buf, Pinia/Nuxt UI, existing PowerX capability registry and IAM/RBAC services. (029-metadata-governance)
+- PostgreSQL tables for metadata definitions, tag bindings, references, audit events through existing audit infrastructure; seed YAML under `backend/config/metadata_governance`. (029-metadata-governance)
 
 - Go 1.24（backend），Node 20（Web Admin 热更新面板），Go 1.21（px-plugin CLI） + Gin HTTP 栈、google.golang.org/grpc、Buf toolchain、GORM + PostgreSQL、Redis（队列与 Feature Flag）、MinIO/S3 SDK（离线包存储）、OpenTelemetry + Prometheus Exporter、PowerX CLI (`powerx`, `px-plugin`) (001-install-plugin-pxp)
 - Go 1.24 (backend services, CLIs), Node 20 (validation scripts), Go 1.21 (px-plugin CLI) + Gin HTTP stack, google.golang.org/grpc, Buf toolchain, GORM + PostgreSQL, Redis, MinIO/S3 SDK, OpenTelemetry + Prometheus exporters (010-agent-model-setting)
@@ -46,9 +48,9 @@ tests/
 Go 1.24（backend），Node 20（Web Admin 热更新面板），Go 1.21（px-plugin CLI）: Follow standard conventions
 
 ## Recent Changes
+- 029-metadata-governance: Added Go 1.24 for backend/CoreX services and CLIs; TypeScript with Nuxt 4/Vue 3 for Web Admin; Buf toolchain for gRPC contracts. + Gin HTTP stack, GORM, PostgreSQL JSONB, Redis only if later used for read caches, google.golang.org/grpc, Buf, Pinia/Nuxt UI, existing PowerX capability registry and IAM/RBAC services.
 - 027-monitor-center: Added Go 1.24（backend）, TypeScript + Nuxt 4（web-admin） + Gin HTTP, GORM, PostgreSQL, Redis, systemd/ops scripts, Nuxt UI
 - 026-iam: Added Go 1.24（backend），TypeScript（Nuxt 4 / Vue 3，web-admin） + Gin HTTP、gRPC（Buf contracts）、GORM、Pinia、Nuxt UI
-- 025-powerx-docker-systemd: Added Go 1.24（backend services）、TypeScript/Nuxt 4（web-admin） + Gin HTTP、gRPC（Buf contracts）、GORM、PostgreSQL、Redis、Loki、Grafana、Promtail
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/backend/internal/transport/http/admin/system/setup_handler.go
+++ b/backend/internal/transport/http/admin/system/setup_handler.go
@@ -1683,7 +1683,7 @@ func defaultSetupMigrateCmd() string {
 }
 
 func defaultSetupSeedCmd() string {
-	return "if [ -x ./database ]; then ./database seed -config \"${POWERX_CONFIG:-etc/config.yaml}\"; elif [ -d backend/cmd/database ] && command -v go >/dev/null 2>&1; then cd backend && go run ./cmd/database seed -config \"${POWERX_CONFIG:-etc/config.yaml}\"; else echo 'database seed tool not found (expect ./database or go toolchain in dev)' >&2; exit 127; fi"
+	return "if [ -x ./database ] && [ -x ./platform_capability_seed ]; then ./database seed -config \"${POWERX_CONFIG:-etc/config.yaml}\" && ./platform_capability_seed -config \"${POWERX_CONFIG:-etc/config.yaml}\"; elif [ -d backend/cmd/database ] && [ -d backend/cmd/platform_capability_seed ] && command -v go >/dev/null 2>&1; then cd backend && go run ./cmd/database seed -config \"${POWERX_CONFIG:-etc/config.yaml}\" && go run ./cmd/platform_capability_seed -config \"${POWERX_CONFIG:-etc/config.yaml}\"; else echo 'seed tools not found (expect ./database + ./platform_capability_seed or go toolchain in dev)' >&2; exit 127; fi"
 }
 
 func asMap(v any) map[string]any {

--- a/docs/guides/deploy/025-powerx-docker-systemd/systemd-dev/01-deploy-dev-config-start.md
+++ b/docs/guides/deploy/025-powerx-docker-systemd/systemd-dev/01-deploy-dev-config-start.md
@@ -237,6 +237,28 @@ sudo bash backend/scripts/ops/switch-develop-systemd.sh ${POWERX_DEV_VERSION} --
 - 默认 dev service 是 `powerx-dev-backend`、`powerx-dev-web-admin`、`powerx-dev-runner`。
 - 如需临时覆盖 dev root 或 service name，仍可通过 `POWERX_RELEASES_ROOT`、`POWERX_LINKS_ROOT`、`POWERX_RUNTIME_ROOT`、`POWERX_BACKEND_SERVICE` 等环境变量覆盖。
 
+### 12.1.1 切换后的 migrate 和 seed
+
+发布切换不会自动执行 migrate 或 seed。需要按变更类型显式执行：
+
+```bash
+cd /opt/powerx-dev/backend
+
+# 有数据库结构变更时执行
+sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml ./database migrate
+
+# 需要补齐基础种子数据和 Capability Registry 时执行
+sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml make seed
+```
+
+seed 命令语义：
+
+- `make db-seed`：只执行 CoreX / 数据库基础种子。
+- `make capability-seed`：只把 `backend/config/platform_capabilities/*.yaml` 同步到 Capability Registry，并为 active tenants 补齐 registrations。
+- `make seed`：等于 `make db-seed` + `make capability-seed`。
+
+如果只是改 Go 业务逻辑或前端页面，通常不需要 seed。如果新增或修改了 `backend/config/platform_capabilities/*.yaml`，需要执行 `make capability-seed` 或 `make seed`。
+
 ### 12.2 手动切换 symlink
 也可以只更新 `/opt/powerx-dev` 下的 symlink，并重启 dev service：
 

--- a/docs/guides/deploy/025-powerx-docker-systemd/systemd-dev/01-deploy-dev-config-start.md
+++ b/docs/guides/deploy/025-powerx-docker-systemd/systemd-dev/01-deploy-dev-config-start.md
@@ -248,16 +248,18 @@ cd /opt/powerx-dev/backend
 sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml ./database migrate
 
 # 需要补齐基础种子数据和 Capability Registry 时执行
-sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml make seed
+sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml ./database seed
+sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml ./platform_capability_seed
 ```
 
-seed 命令语义：
+seed 命令语义按目录区分：
 
-- `make db-seed`：只执行 CoreX / 数据库基础种子。
-- `make capability-seed`：只把 `backend/config/platform_capabilities/*.yaml` 同步到 Capability Registry，并为 active tenants 补齐 registrations。
-- `make seed`：等于 `make db-seed` + `make capability-seed`。
+- `/opt/powerx-dev/backend` 是发布产物目录，不使用 `make`。
+- `./database seed`：只执行 CoreX / 数据库基础种子。
+- `./platform_capability_seed`：只把 `config/platform_capabilities/*.yaml` 同步到 Capability Registry，并为 active tenants 补齐 registrations。
+- 源码目录才使用 `make seed`，例如 `cd /home/ubuntu/workspace/PowerX && sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml make seed`。
 
-如果只是改 Go 业务逻辑或前端页面，通常不需要 seed。如果新增或修改了 `backend/config/platform_capabilities/*.yaml`，需要执行 `make capability-seed` 或 `make seed`。
+如果只是改 Go 业务逻辑或前端页面，通常不需要 seed。如果新增或修改了 `backend/config/platform_capabilities/*.yaml`，切换新 release 后需要执行 `./platform_capability_seed`；如果同时需要基础数据补齐，再执行 `./database seed`。
 
 ### 12.2 手动切换 symlink
 也可以只更新 `/opt/powerx-dev` 下的 symlink，并重启 dev service：
@@ -285,4 +287,4 @@ sudo systemctl restart powerx-dev-backend powerx-dev-web-admin powerx-dev-runner
 - `powerx-web-admin`
 - `powerx-runner`
 
-生产环境可以继续使用默认参数。dev 环境必须按 14.1 同时覆盖 root、service name 和 health url；不能只覆盖 root，否则仍可能重启默认生产 service。
+生产环境可以继续使用默认参数。dev 环境必须使用 `switch-develop-systemd.sh` 或同时覆盖 root、service name 和 health url；不能只覆盖 root，否则仍可能重启默认生产 service。

--- a/docs/guides/deploy/025-powerx-docker-systemd/systemd-dev/02-verify-and-troubleshoot.md
+++ b/docs/guides/deploy/025-powerx-docker-systemd/systemd-dev/02-verify-and-troubleshoot.md
@@ -122,14 +122,17 @@ grep -n "dsn\\|schema" /etc/powerx-dev/config.yaml
 
 ```bash
 cd /opt/powerx-dev/backend
-POWERX_CONFIG=/etc/powerx-dev/config.yaml ./database migrate
+sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml ./database migrate
 ```
 
 补 seed：
 ```bash
 cd /opt/powerx-dev/backend
-POWERX_CONFIG=/etc/powerx-dev/config.yaml ./database seed
+sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml ./database seed
+sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml ./platform_capability_seed
 ```
+
+如果 `/opt/powerx-dev/backend/platform_capability_seed` 不存在，说明当前 dev release 是旧产物；重新执行 `make dist` 并通过 `switch-develop-systemd.sh` 切换到新 release 后再补 seed。
 
 ## 8. 回滚 dev release
 ```bash

--- a/docs/guides/deploy/025-powerx-docker-systemd/systemd/01-deploy-config-start.md
+++ b/docs/guides/deploy/025-powerx-docker-systemd/systemd/01-deploy-config-start.md
@@ -192,7 +192,7 @@ POWERX_GATEWAY_WS_BASE_URL=wss://agent.example.com
 发布模式建议：
 - 代码升级（无 DB 变更）：只执行 `make dist + switch-release`，不走 `/setup`。
 - 结构升级（有 migration）：发布后执行 `POWERX_CONFIG=/etc/powerx/config.yaml ./database migrate`，不自动 seed。
-- 初始化或补数（需要 seed）：显式执行 `POWERX_CONFIG=/etc/powerx/config.yaml ./database seed`，避免与常规发布绑定。
+- 初始化或补数（需要 seed）：显式执行 `POWERX_CONFIG=/etc/powerx/config.yaml ./database seed` 和 `POWERX_CONFIG=/etc/powerx/config.yaml ./platform_capability_seed`，避免与常规发布绑定。
 
 运行时持久目录：
 - release 包只放不可变程序产物，位于 `/opt/powerx/releases/<version>`。
@@ -277,9 +277,11 @@ cd /opt/powerx/backend
 POWERX_CONFIG=/etc/powerx/config.yaml ./database migrate
 # 仅在需要初始化/补数时执行
 # POWERX_CONFIG=/etc/powerx/config.yaml ./database seed
+# POWERX_CONFIG=/etc/powerx/config.yaml ./platform_capability_seed
 ```
 说明：
-- 发布产物目录请使用 `./database migrate|seed`，不要使用 `./powerx database migrate`（`powerx` 是服务进程入口，不是迁移 CLI）。
+- 发布产物目录请使用 `./database migrate|seed` 与 `./platform_capability_seed`，不要使用 `./powerx database migrate`（`powerx` 是服务进程入口，不是迁移 CLI）。
+- 源码 checkout 目录可以使用 `POWERX_CONFIG=/etc/powerx/config.yaml make seed`；发布产物目录通常没有 Makefile，因此使用上面的二进制命令。
 
 ## 11.1 安装后租户与用户管理（给同事开账号）
 
@@ -320,6 +322,7 @@ export POWERX_DEMO_PASSWORD='change_me_demo_password'
 ```bash
 cd /opt/powerx/backend
 POWERX_CONFIG=/etc/powerx/config.yaml ./database seed
+POWERX_CONFIG=/etc/powerx/config.yaml ./platform_capability_seed
 ```
 
 说明：

--- a/docs/guides/develop/open_capability/readme.md
+++ b/docs/guides/develop/open_capability/readme.md
@@ -185,6 +185,25 @@ make capability-seed
 
 `make capability-seed` 只做 `backend/config/platform_capabilities/*.yaml` 到 Capability Registry 的同步，并为 active tenants 补齐 registrations；它不执行 migrate，也不执行全量 seed。执行后可以用 `/api/v1/tenant/capabilities/resolve` 验证当前租户是否已经能解析到新增 capability。若新增了真实 HTTP route，还必须重启 PowerX Core 到最新代码，否则 Registry 能解析，但转发到旧进程仍会返回 404。
 
+如果部署后希望同时补齐 CoreX 基础种子数据和 Capability Registry，可以执行：
+
+```bash
+make seed
+```
+
+命令边界：
+
+- `make capability-check`：只做构建/代码侧校验，不写运行库。
+- `make db-seed`：只执行 CoreX / 数据库基础种子。
+- `make capability-seed`：只同步 Capability Registry。
+- `make seed`：等于 `make db-seed` + `make capability-seed`。
+
+远程 dev 环境必须显式指定运行时配置，避免写到错误数据库：
+
+```bash
+POWERX_CONFIG=/etc/powerx-dev/config.yaml make seed
+```
+
 ### 失败时怎么处理
 
 - 缺真实 transport/service：先实现接口、service、repository、权限和测试，再登记 capability。

--- a/make_files/README.md
+++ b/make_files/README.md
@@ -72,7 +72,9 @@ make_files/
 ### database.mk - 数据库任务
 
 * `make db-migrate` - 数据库迁移
-* `make db-seed` - 数据库种子数据
+* `make db-seed` - 只执行 CoreX / 数据库基础种子数据
+* `make capability-seed` - 只同步 `backend/config/platform_capabilities/*.yaml` 到 Capability Registry
+* `make seed` - 执行 `db-seed` 后再执行 `capability-seed`
 * `make db-reset` - 重置数据库
 
 ### mcp.mk - MCP 服务任务

--- a/make_files/capability.mk
+++ b/make_files/capability.mk
@@ -6,6 +6,7 @@ CAPABILITY_AUDIT_CANDIDATE_FILE ?=
 CAPABILITY_AUDIT_FIX ?= 0
 CAPABILITY_AUDIT_FIX_OUTPUT ?= tmp/capability-audit/missing.platform-capabilities.yaml
 CAPABILITY_CHECK_GENERATED ?= tmp/capability-check/generated.platform-capabilities.yaml
+CAPABILITY_SEED_CONFIG ?= $(if $(POWERX_CONFIG),$(POWERX_CONFIG),etc/config.yaml)
 
 capability-audit:
 	cd backend && CAPABILITY_AUDIT_SCAN="$(CAPABILITY_AUDIT_SCAN)" CAPABILITY_AUDIT_REQUIRED="$(CAPABILITY_AUDIT_REQUIRED)" CAPABILITY_AUDIT_CANDIDATE_FILE="$(CAPABILITY_AUDIT_CANDIDATE_FILE)" CAPABILITY_AUDIT_FIX="$(CAPABILITY_AUDIT_FIX)" go run ./cmd/capability_audit \
@@ -19,4 +20,4 @@ capability-check:
 	$(MAKE) capability-audit CAPABILITY_AUDIT_CANDIDATE_FILE="$(CAPABILITY_CHECK_GENERATED)"
 
 capability-seed:
-	cd backend && go run ./cmd/platform_capability_seed -config etc/config.yaml
+	cd backend && go run ./cmd/platform_capability_seed -config "$(CAPABILITY_SEED_CONFIG)"

--- a/make_files/database.mk
+++ b/make_files/database.mk
@@ -37,7 +37,9 @@ db-rollback:
 	@echo "执行数据库回滚..."
 	@cd backend && go run ./cmd/database rollback
 
-.PHONY: db-seed
+.PHONY: seed db-seed
+seed: db-seed capability-seed
+
 db-seed:
 	@echo "填充数据库种子数据..."
 	@cd backend && go run ./cmd/database seed
@@ -70,6 +72,7 @@ iam-migration-fix-owner:
 help:
 	@echo "数据库操作命令:"
 	@echo "  make db-migrate    - 执行数据库迁移"
+	@echo "  make seed          - 填充 CoreX 种子数据并同步 Capability Registry"
 	@echo "  make db-rollback   - 回滚数据库迁移"
 	@echo "  make db-seed       - 填充数据库种子数据"
 	@echo "  make db-refresh    - 刷新数据库（回滚+迁移+种子）"

--- a/make_files/dist.mk
+++ b/make_files/dist.mk
@@ -23,6 +23,8 @@ dist-systemd:
 	(cd backend && go build -o "../$(DIST_OUT_DIR)/backend/powerx" ./cmd/app); \
 	echo "[dist] build database tool"; \
 	(cd backend && go build -o "../$(DIST_OUT_DIR)/backend/database" ./cmd/database); \
+	echo "[dist] build platform capability seed tool"; \
+	(cd backend && go build -o "../$(DIST_OUT_DIR)/backend/platform_capability_seed" ./cmd/platform_capability_seed); \
 	echo "[dist] build media tool"; \
 	(cd backend && go build -o "../$(DIST_OUT_DIR)/backend/media_tool" ./cmd/media_tool); \
 		echo "[dist] copy backend runtime config"; \

--- a/specs/029-metadata-governance/checklists/requirements.md
+++ b/specs/029-metadata-governance/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Metadata Governance
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Initial validation passed after generating `spec.md` from `docs/plan/metadata-governance`.
+- Detailed API contracts, data model fields, capability declarations, and implementation tasks should be produced in the planning phase, not embedded in this stakeholder-facing specification.

--- a/specs/029-metadata-governance/contracts/http-openapi.yaml
+++ b/specs/029-metadata-governance/contracts/http-openapi.yaml
@@ -1,0 +1,1081 @@
+openapi: 3.0.3
+info:
+  title: PowerX Metadata Governance Admin API
+  version: 0.1.0
+  description: Design contract for tenant-scoped metadata governance.
+servers:
+  - url: /api/v1
+security:
+  - bearerAuth: []
+paths:
+  /admin/metadata/dictionaries:
+    get:
+      operationId: listDictionaryNamespaces
+      tags: [MetadataDictionaries]
+      parameters:
+        - $ref: '#/components/parameters/Module'
+        - $ref: '#/components/parameters/Status'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Locale'
+      responses:
+        '200':
+          description: Dictionary namespaces.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryNamespaceListResponse'
+    post:
+      operationId: createDictionaryNamespace
+      tags: [MetadataDictionaries]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDictionaryNamespaceRequest'
+      responses:
+        '200':
+          description: Created dictionary namespace.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryNamespaceResponse'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /admin/metadata/dictionaries/{namespace_uuid}:
+    patch:
+      operationId: updateDictionaryNamespace
+      tags: [MetadataDictionaries]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceUUID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDictionaryNamespaceRequest'
+      responses:
+        '200':
+          description: Updated dictionary namespace.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryNamespaceResponse'
+  /admin/metadata/dictionaries/{namespace_uuid}/items:
+    get:
+      operationId: listDictionaryItems
+      tags: [MetadataDictionaries]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceUUID'
+        - $ref: '#/components/parameters/Status'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Locale'
+      responses:
+        '200':
+          description: Dictionary items.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryItemListResponse'
+    post:
+      operationId: createDictionaryItem
+      tags: [MetadataDictionaries]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceUUID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDictionaryItemRequest'
+      responses:
+        '200':
+          description: Created dictionary item.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryItemResponse'
+  /admin/metadata/dictionary-items/{item_uuid}:
+    patch:
+      operationId: updateDictionaryItem
+      tags: [MetadataDictionaries]
+      parameters:
+        - $ref: '#/components/parameters/ItemUUID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDictionaryItemRequest'
+      responses:
+        '200':
+          description: Updated dictionary item.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DictionaryItemResponse'
+    delete:
+      operationId: deleteDictionaryItem
+      tags: [MetadataDictionaries]
+      parameters:
+        - $ref: '#/components/parameters/ItemUUID'
+      responses:
+        '200':
+          $ref: '#/components/responses/Deleted'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /admin/metadata/taxonomies:
+    get:
+      operationId: listTaxonomies
+      tags: [MetadataTaxonomies]
+      parameters:
+        - $ref: '#/components/parameters/Module'
+        - $ref: '#/components/parameters/Status'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Locale'
+      responses:
+        '200':
+          description: Taxonomies.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxonomyListResponse'
+    post:
+      operationId: createTaxonomy
+      tags: [MetadataTaxonomies]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTaxonomyRequest'
+      responses:
+        '200':
+          description: Created taxonomy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxonomyResponse'
+  /admin/metadata/taxonomies/{taxonomy_uuid}/nodes:
+    get:
+      operationId: listTaxonomyNodes
+      tags: [MetadataTaxonomies]
+      parameters:
+        - $ref: '#/components/parameters/TaxonomyUUID'
+        - $ref: '#/components/parameters/Status'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Locale'
+      responses:
+        '200':
+          description: Taxonomy nodes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxonomyNodeTreeResponse'
+    post:
+      operationId: createTaxonomyNode
+      tags: [MetadataTaxonomies]
+      parameters:
+        - $ref: '#/components/parameters/TaxonomyUUID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTaxonomyNodeRequest'
+      responses:
+        '200':
+          description: Created taxonomy node.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxonomyNodeResponse'
+  /admin/metadata/taxonomy-nodes/{node_uuid}:
+    patch:
+      operationId: updateTaxonomyNode
+      tags: [MetadataTaxonomies]
+      parameters:
+        - $ref: '#/components/parameters/NodeUUID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTaxonomyNodeRequest'
+      responses:
+        '200':
+          description: Updated taxonomy node.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxonomyNodeResponse'
+    delete:
+      operationId: deleteTaxonomyNode
+      tags: [MetadataTaxonomies]
+      parameters:
+        - $ref: '#/components/parameters/NodeUUID'
+      responses:
+        '200':
+          $ref: '#/components/responses/Deleted'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /admin/metadata/taxonomy-nodes/{node_uuid}/move:
+    post:
+      operationId: moveTaxonomyNode
+      tags: [MetadataTaxonomies]
+      parameters:
+        - $ref: '#/components/parameters/NodeUUID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MoveTaxonomyNodeRequest'
+      responses:
+        '200':
+          description: Moved taxonomy node.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxonomyNodeResponse'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /admin/metadata/tags:
+    get:
+      operationId: listTags
+      tags: [MetadataTags]
+      parameters:
+        - $ref: '#/components/parameters/Namespace'
+        - $ref: '#/components/parameters/ResourceType'
+        - $ref: '#/components/parameters/Status'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Locale'
+      responses:
+        '200':
+          description: Tags.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagListResponse'
+    post:
+      operationId: createTag
+      tags: [MetadataTags]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTagRequest'
+      responses:
+        '200':
+          description: Created tag.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagResponse'
+  /admin/metadata/tags/{tag_uuid}:
+    patch:
+      operationId: updateTag
+      tags: [MetadataTags]
+      parameters:
+        - $ref: '#/components/parameters/TagUUID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTagRequest'
+      responses:
+        '200':
+          description: Updated tag.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagResponse'
+    delete:
+      operationId: deleteTag
+      tags: [MetadataTags]
+      parameters:
+        - $ref: '#/components/parameters/TagUUID'
+      responses:
+        '200':
+          $ref: '#/components/responses/Deleted'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /admin/metadata/tags/merge:
+    post:
+      operationId: mergeTags
+      tags: [MetadataTags]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MergeTagsRequest'
+      responses:
+        '200':
+          description: Merge result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeTagsResponse'
+  /admin/metadata/tag-bindings:
+    get:
+      operationId: listTagBindings
+      tags: [MetadataTagBindings]
+      parameters:
+        - $ref: '#/components/parameters/ResourceType'
+        - $ref: '#/components/parameters/ResourceUUID'
+        - $ref: '#/components/parameters/Locale'
+      responses:
+        '200':
+          description: Tag bindings.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagBindingListResponse'
+    put:
+      operationId: replaceTagBindings
+      tags: [MetadataTagBindings]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReplaceTagBindingsRequest'
+      responses:
+        '200':
+          description: Replaced tag bindings.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagBindingListResponse'
+  /admin/metadata/resource-types:
+    get:
+      operationId: listResourceTypes
+      tags: [MetadataResourceTypes]
+      parameters:
+        - $ref: '#/components/parameters/Module'
+        - $ref: '#/components/parameters/Status'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Locale'
+      responses:
+        '200':
+          description: Resource types.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceTypeListResponse'
+    post:
+      operationId: registerResourceType
+      tags: [MetadataResourceTypes]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterResourceTypeRequest'
+      responses:
+        '200':
+          description: Registered resource type.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceTypeResponse'
+  /admin/metadata/resource-types/{resource_type_uuid}:
+    patch:
+      operationId: updateResourceType
+      tags: [MetadataResourceTypes]
+      parameters:
+        - name: resource_type_uuid
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateResourceTypeRequest'
+      responses:
+        '200':
+          description: Updated resource type.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceTypeResponse'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    Locale:
+      name: locale
+      in: query
+      schema:
+        type: string
+        example: zh-CN
+    Module:
+      name: module
+      in: query
+      schema:
+        type: string
+    Namespace:
+      name: namespace
+      in: query
+      schema:
+        type: string
+    ResourceType:
+      name: resource_type
+      in: query
+      schema:
+        type: string
+    ResourceUUID:
+      name: resource_uuid
+      in: query
+      required: true
+      schema:
+        type: string
+        format: uuid
+    Status:
+      name: status
+      in: query
+      schema:
+        $ref: '#/components/schemas/MetadataStatus'
+    Search:
+      name: q
+      in: query
+      schema:
+        type: string
+    Page:
+      name: page
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    PageSize:
+      name: page_size
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 500
+        default: 20
+    NamespaceUUID:
+      name: namespace_uuid
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    ItemUUID:
+      name: item_uuid
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    TaxonomyUUID:
+      name: taxonomy_uuid
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    NodeUUID:
+      name: node_uuid
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    TagUUID:
+      name: tag_uuid
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    Deleted:
+      description: Deleted.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SuccessResponse'
+    Conflict:
+      description: Conflict caused by uniqueness, stale version, or protected references.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    MetadataStatus:
+      type: string
+      enum: [enabled, disabled, archived]
+    I18nMap:
+      type: object
+      additionalProperties:
+        type: string
+      required: [zh-CN]
+      example:
+        zh-CN: 客户等级
+        en-US: Customer Level
+    DisplayFields:
+      type: object
+      properties:
+        display_name:
+          type: string
+        display_description:
+          type: string
+        display_locale:
+          type: string
+        display_locale_missing:
+          type: boolean
+      required: [display_name, display_locale, display_locale_missing]
+    Pagination:
+      type: object
+      properties:
+        page:
+          type: integer
+        page_size:
+          type: integer
+        total:
+          type: integer
+      required: [page, page_size, total]
+    SuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+      required: [success]
+    ErrorResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            references:
+              type: array
+              items:
+                $ref: '#/components/schemas/ReferenceSummary'
+        request_id:
+          type: string
+        timestamp:
+          type: string
+      required: [success, error]
+    ReferenceSummary:
+      type: object
+      properties:
+        resource_type:
+          type: string
+        resource_uuid:
+          type: string
+          format: uuid
+        field_name:
+          type: string
+        count:
+          type: integer
+      required: [resource_type, count]
+    CreateDictionaryNamespaceRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+        module:
+          type: string
+        name_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+      required: [namespace, module, name_i18n]
+    UpdateDictionaryNamespaceRequest:
+      type: object
+      properties:
+        name_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        status:
+          $ref: '#/components/schemas/MetadataStatus'
+    DictionaryNamespace:
+      allOf:
+        - $ref: '#/components/schemas/DisplayFields'
+        - type: object
+          properties:
+            uuid:
+              type: string
+              format: uuid
+            namespace:
+              type: string
+            module:
+              type: string
+            name_i18n:
+              $ref: '#/components/schemas/I18nMap'
+            description_i18n:
+              $ref: '#/components/schemas/I18nMap'
+            status:
+              $ref: '#/components/schemas/MetadataStatus'
+            item_count:
+              type: integer
+          required: [uuid, namespace, module, name_i18n, status]
+    CreateDictionaryItemRequest:
+      type: object
+      properties:
+        code:
+          type: string
+        label_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        sort_order:
+          type: integer
+        metadata:
+          type: object
+      required: [code, label_i18n]
+    UpdateDictionaryItemRequest:
+      type: object
+      properties:
+        label_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        sort_order:
+          type: integer
+        status:
+          $ref: '#/components/schemas/MetadataStatus'
+        metadata:
+          type: object
+    DictionaryItem:
+      allOf:
+        - $ref: '#/components/schemas/DisplayFields'
+        - type: object
+          properties:
+            uuid:
+              type: string
+              format: uuid
+            namespace_uuid:
+              type: string
+              format: uuid
+            code:
+              type: string
+            label_i18n:
+              $ref: '#/components/schemas/I18nMap'
+            status:
+              $ref: '#/components/schemas/MetadataStatus'
+            sort_order:
+              type: integer
+            reference_count:
+              type: integer
+          required: [uuid, namespace_uuid, code, label_i18n, status]
+    CreateTaxonomyRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+        module:
+          type: string
+        name_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        max_depth:
+          type: integer
+          minimum: 1
+      required: [namespace, module, name_i18n, max_depth]
+    Taxonomy:
+      allOf:
+        - $ref: '#/components/schemas/DisplayFields'
+        - type: object
+          properties:
+            uuid:
+              type: string
+              format: uuid
+            namespace:
+              type: string
+            module:
+              type: string
+            name_i18n:
+              $ref: '#/components/schemas/I18nMap'
+            max_depth:
+              type: integer
+            status:
+              $ref: '#/components/schemas/MetadataStatus'
+          required: [uuid, namespace, module, name_i18n, max_depth, status]
+    CreateTaxonomyNodeRequest:
+      type: object
+      properties:
+        parent_uuid:
+          type: string
+          format: uuid
+          nullable: true
+        code:
+          type: string
+        label_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        sort_order:
+          type: integer
+      required: [code, label_i18n]
+    UpdateTaxonomyNodeRequest:
+      type: object
+      properties:
+        label_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        sort_order:
+          type: integer
+        status:
+          $ref: '#/components/schemas/MetadataStatus'
+        version:
+          type: integer
+      required: [version]
+    MoveTaxonomyNodeRequest:
+      type: object
+      properties:
+        target_parent_uuid:
+          type: string
+          format: uuid
+          nullable: true
+        sort_order:
+          type: integer
+        version:
+          type: integer
+      required: [version]
+    TaxonomyNode:
+      allOf:
+        - $ref: '#/components/schemas/DisplayFields'
+        - type: object
+          properties:
+            uuid:
+              type: string
+              format: uuid
+            taxonomy_uuid:
+              type: string
+              format: uuid
+            parent_uuid:
+              type: string
+              format: uuid
+              nullable: true
+            code:
+              type: string
+            label_i18n:
+              $ref: '#/components/schemas/I18nMap'
+            path:
+              type: string
+            depth:
+              type: integer
+            sort_order:
+              type: integer
+            status:
+              $ref: '#/components/schemas/MetadataStatus'
+            reference_count:
+              type: integer
+            version:
+              type: integer
+          required: [uuid, taxonomy_uuid, code, label_i18n, path, depth, status, version]
+    CreateTagRequest:
+      type: object
+      properties:
+        namespace:
+          type: string
+        resource_type:
+          type: string
+        code:
+          type: string
+        label_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        color:
+          type: string
+      required: [namespace, resource_type, code, label_i18n]
+    UpdateTagRequest:
+      type: object
+      properties:
+        label_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        color:
+          type: string
+        status:
+          $ref: '#/components/schemas/MetadataStatus'
+    Tag:
+      allOf:
+        - $ref: '#/components/schemas/DisplayFields'
+        - type: object
+          properties:
+            uuid:
+              type: string
+              format: uuid
+            namespace:
+              type: string
+            resource_type:
+              type: string
+            code:
+              type: string
+            label_i18n:
+              $ref: '#/components/schemas/I18nMap'
+            color:
+              type: string
+            status:
+              $ref: '#/components/schemas/MetadataStatus'
+            usage_count:
+              type: integer
+          required: [uuid, namespace, resource_type, code, label_i18n, status]
+    MergeTagsRequest:
+      type: object
+      properties:
+        source_tag_uuid:
+          type: string
+          format: uuid
+        target_tag_uuid:
+          type: string
+          format: uuid
+      required: [source_tag_uuid, target_tag_uuid]
+    MergeTagsResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          properties:
+            moved_bindings:
+              type: integer
+      required: [success, data]
+    ReplaceTagBindingsRequest:
+      type: object
+      properties:
+        resource_type:
+          type: string
+        resource_uuid:
+          type: string
+          format: uuid
+        tag_uuids:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required: [resource_type, resource_uuid, tag_uuids]
+    TagBinding:
+      type: object
+      properties:
+        tag_uuid:
+          type: string
+          format: uuid
+        resource_type:
+          type: string
+        resource_uuid:
+          type: string
+          format: uuid
+        tag:
+          $ref: '#/components/schemas/Tag'
+      required: [tag_uuid, resource_type, resource_uuid]
+    RegisterResourceTypeRequest:
+      type: object
+      properties:
+        resource_type:
+          type: string
+        module:
+          type: string
+        name_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        validator_key:
+          type: string
+        binding_enabled:
+          type: boolean
+      required: [resource_type, module, name_i18n]
+    UpdateResourceTypeRequest:
+      type: object
+      properties:
+        name_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        validator_key:
+          type: string
+        binding_enabled:
+          type: boolean
+        status:
+          $ref: '#/components/schemas/MetadataStatus'
+    ResourceType:
+      allOf:
+        - $ref: '#/components/schemas/DisplayFields'
+        - type: object
+          properties:
+            uuid:
+              type: string
+              format: uuid
+            resource_type:
+              type: string
+            module:
+              type: string
+            name_i18n:
+              $ref: '#/components/schemas/I18nMap'
+            validator_key:
+              type: string
+            binding_enabled:
+              type: boolean
+            validator_status:
+              type: string
+              enum: [available, missing, disabled]
+            status:
+              $ref: '#/components/schemas/MetadataStatus'
+          required: [uuid, resource_type, module, name_i18n, binding_enabled, validator_status, status]
+    DictionaryNamespaceResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: '#/components/schemas/DictionaryNamespace'
+      required: [success, data]
+    DictionaryNamespaceListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DictionaryNamespace'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+      required: [success, data, pagination]
+    DictionaryItemResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: '#/components/schemas/DictionaryItem'
+      required: [success, data]
+    DictionaryItemListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DictionaryItem'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+      required: [success, data, pagination]
+    TaxonomyResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: '#/components/schemas/Taxonomy'
+      required: [success, data]
+    TaxonomyListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Taxonomy'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+      required: [success, data, pagination]
+    TaxonomyNodeResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: '#/components/schemas/TaxonomyNode'
+      required: [success, data]
+    TaxonomyNodeTreeResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxonomyNode'
+      required: [success, data]
+    TagResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: '#/components/schemas/Tag'
+      required: [success, data]
+    TagListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tag'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+      required: [success, data, pagination]
+    TagBindingListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagBinding'
+      required: [success, data]
+    ResourceTypeResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: '#/components/schemas/ResourceType'
+      required: [success, data]
+    ResourceTypeListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceType'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+      required: [success, data, pagination]

--- a/specs/029-metadata-governance/contracts/http-openapi.yaml
+++ b/specs/029-metadata-governance/contracts/http-openapi.yaml
@@ -162,6 +162,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaxonomyResponse'
+  /admin/metadata/taxonomies/{taxonomy_uuid}:
+    patch:
+      operationId: updateTaxonomy
+      tags: [MetadataTaxonomies]
+      parameters:
+        - $ref: '#/components/parameters/TaxonomyUUID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTaxonomyRequest'
+      responses:
+        '200':
+          description: Updated taxonomy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxonomyResponse'
   /admin/metadata/taxonomies/{taxonomy_uuid}/nodes:
     get:
       operationId: listTaxonomyNodes
@@ -706,6 +725,18 @@ components:
           type: integer
           minimum: 1
       required: [namespace, module, name_i18n, max_depth]
+    UpdateTaxonomyRequest:
+      type: object
+      properties:
+        name_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        description_i18n:
+          $ref: '#/components/schemas/I18nMap'
+        max_depth:
+          type: integer
+          minimum: 1
+        status:
+          $ref: '#/components/schemas/MetadataStatus'
     Taxonomy:
       allOf:
         - $ref: '#/components/schemas/DisplayFields'

--- a/specs/029-metadata-governance/contracts/metadata.proto
+++ b/specs/029-metadata-governance/contracts/metadata.proto
@@ -1,0 +1,378 @@
+syntax = "proto3";
+
+package powerx.metadata.v1;
+
+option go_package = "github.com/ArtisanCloud/PowerX/api/grpc/gen/go/powerx/metadata/v1;metadatav1";
+
+service MetadataGovernanceService {
+  rpc ListDictionaryNamespaces(ListDictionaryNamespacesRequest) returns (ListDictionaryNamespacesResponse);
+  rpc CreateDictionaryNamespace(CreateDictionaryNamespaceRequest) returns (DictionaryNamespaceResponse);
+  rpc ListDictionaryItems(ListDictionaryItemsRequest) returns (ListDictionaryItemsResponse);
+  rpc CreateDictionaryItem(CreateDictionaryItemRequest) returns (DictionaryItemResponse);
+  rpc UpdateDictionaryItem(UpdateDictionaryItemRequest) returns (DictionaryItemResponse);
+  rpc DeleteDictionaryItem(DeleteDictionaryItemRequest) returns (DeleteResponse);
+
+  rpc ListTaxonomies(ListTaxonomiesRequest) returns (ListTaxonomiesResponse);
+  rpc CreateTaxonomy(CreateTaxonomyRequest) returns (TaxonomyResponse);
+  rpc ListTaxonomyNodes(ListTaxonomyNodesRequest) returns (ListTaxonomyNodesResponse);
+  rpc CreateTaxonomyNode(CreateTaxonomyNodeRequest) returns (TaxonomyNodeResponse);
+  rpc MoveTaxonomyNode(MoveTaxonomyNodeRequest) returns (TaxonomyNodeResponse);
+  rpc DeleteTaxonomyNode(DeleteTaxonomyNodeRequest) returns (DeleteResponse);
+
+  rpc ListTags(ListTagsRequest) returns (ListTagsResponse);
+  rpc CreateTag(CreateTagRequest) returns (TagResponse);
+  rpc UpdateTag(UpdateTagRequest) returns (TagResponse);
+  rpc MergeTags(MergeTagsRequest) returns (MergeTagsResponse);
+  rpc DeleteTag(DeleteTagRequest) returns (DeleteResponse);
+
+  rpc ListTagBindings(ListTagBindingsRequest) returns (ListTagBindingsResponse);
+  rpc ReplaceTagBindings(ReplaceTagBindingsRequest) returns (ListTagBindingsResponse);
+
+  rpc ListResourceTypes(ListResourceTypesRequest) returns (ListResourceTypesResponse);
+  rpc RegisterResourceType(RegisterResourceTypeRequest) returns (ResourceTypeResponse);
+  rpc UpdateResourceType(UpdateResourceTypeRequest) returns (ResourceTypeResponse);
+}
+
+enum MetadataStatus {
+  METADATA_STATUS_UNSPECIFIED = 0;
+  METADATA_STATUS_ENABLED = 1;
+  METADATA_STATUS_DISABLED = 2;
+  METADATA_STATUS_ARCHIVED = 3;
+}
+
+message I18nMap {
+  map<string, string> values = 1;
+}
+
+message Display {
+  string display_name = 1;
+  string display_description = 2;
+  string display_locale = 3;
+  bool display_locale_missing = 4;
+}
+
+message PaginationRequest {
+  int32 page = 1;
+  int32 page_size = 2;
+}
+
+message PaginationResponse {
+  int32 page = 1;
+  int32 page_size = 2;
+  int64 total = 3;
+}
+
+message ReferenceSummary {
+  string resource_type = 1;
+  string resource_uuid = 2;
+  string field_name = 3;
+  int64 count = 4;
+}
+
+message DictionaryNamespace {
+  string uuid = 1;
+  string namespace = 2;
+  string module = 3;
+  I18nMap name_i18n = 4;
+  I18nMap description_i18n = 5;
+  MetadataStatus status = 6;
+  int64 item_count = 7;
+  Display display = 8;
+}
+
+message DictionaryItem {
+  string uuid = 1;
+  string namespace_uuid = 2;
+  string code = 3;
+  I18nMap label_i18n = 4;
+  I18nMap description_i18n = 5;
+  int32 sort_order = 6;
+  MetadataStatus status = 7;
+  int64 reference_count = 8;
+  Display display = 9;
+}
+
+message Taxonomy {
+  string uuid = 1;
+  string namespace = 2;
+  string module = 3;
+  I18nMap name_i18n = 4;
+  I18nMap description_i18n = 5;
+  int32 max_depth = 6;
+  MetadataStatus status = 7;
+  Display display = 8;
+}
+
+message TaxonomyNode {
+  string uuid = 1;
+  string taxonomy_uuid = 2;
+  string parent_uuid = 3;
+  string code = 4;
+  I18nMap label_i18n = 5;
+  I18nMap description_i18n = 6;
+  string path = 7;
+  int32 depth = 8;
+  int32 sort_order = 9;
+  MetadataStatus status = 10;
+  int64 reference_count = 11;
+  int64 version = 12;
+  Display display = 13;
+}
+
+message Tag {
+  string uuid = 1;
+  string namespace = 2;
+  string resource_type = 3;
+  string code = 4;
+  I18nMap label_i18n = 5;
+  I18nMap description_i18n = 6;
+  string color = 7;
+  MetadataStatus status = 8;
+  int64 usage_count = 9;
+  Display display = 10;
+}
+
+message TagBinding {
+  string tag_uuid = 1;
+  string resource_type = 2;
+  string resource_uuid = 3;
+  Tag tag = 4;
+}
+
+message ResourceType {
+  string uuid = 1;
+  string resource_type = 2;
+  string module = 3;
+  I18nMap name_i18n = 4;
+  I18nMap description_i18n = 5;
+  string validator_key = 6;
+  bool binding_enabled = 7;
+  string validator_status = 8;
+  MetadataStatus status = 9;
+  Display display = 10;
+}
+
+message ListDictionaryNamespacesRequest {
+  string module = 1;
+  MetadataStatus status = 2;
+  string q = 3;
+  string locale = 4;
+  PaginationRequest pagination = 5;
+}
+
+message ListDictionaryNamespacesResponse {
+  repeated DictionaryNamespace data = 1;
+  PaginationResponse pagination = 2;
+}
+
+message CreateDictionaryNamespaceRequest {
+  string namespace = 1;
+  string module = 2;
+  I18nMap name_i18n = 3;
+  I18nMap description_i18n = 4;
+}
+
+message DictionaryNamespaceResponse {
+  DictionaryNamespace data = 1;
+}
+
+message ListDictionaryItemsRequest {
+  string namespace_uuid = 1;
+  MetadataStatus status = 2;
+  string q = 3;
+  string locale = 4;
+  PaginationRequest pagination = 5;
+}
+
+message ListDictionaryItemsResponse {
+  repeated DictionaryItem data = 1;
+  PaginationResponse pagination = 2;
+}
+
+message CreateDictionaryItemRequest {
+  string namespace_uuid = 1;
+  string code = 2;
+  I18nMap label_i18n = 3;
+  I18nMap description_i18n = 4;
+  int32 sort_order = 5;
+}
+
+message UpdateDictionaryItemRequest {
+  string item_uuid = 1;
+  I18nMap label_i18n = 2;
+  I18nMap description_i18n = 3;
+  int32 sort_order = 4;
+  MetadataStatus status = 5;
+}
+
+message DictionaryItemResponse {
+  DictionaryItem data = 1;
+}
+
+message DeleteDictionaryItemRequest {
+  string item_uuid = 1;
+}
+
+message ListTaxonomiesRequest {
+  string module = 1;
+  MetadataStatus status = 2;
+  string q = 3;
+  string locale = 4;
+  PaginationRequest pagination = 5;
+}
+
+message ListTaxonomiesResponse {
+  repeated Taxonomy data = 1;
+  PaginationResponse pagination = 2;
+}
+
+message CreateTaxonomyRequest {
+  string namespace = 1;
+  string module = 2;
+  I18nMap name_i18n = 3;
+  I18nMap description_i18n = 4;
+  int32 max_depth = 5;
+}
+
+message TaxonomyResponse {
+  Taxonomy data = 1;
+}
+
+message ListTaxonomyNodesRequest {
+  string taxonomy_uuid = 1;
+  MetadataStatus status = 2;
+  string q = 3;
+  string locale = 4;
+}
+
+message ListTaxonomyNodesResponse {
+  repeated TaxonomyNode data = 1;
+}
+
+message CreateTaxonomyNodeRequest {
+  string taxonomy_uuid = 1;
+  string parent_uuid = 2;
+  string code = 3;
+  I18nMap label_i18n = 4;
+  I18nMap description_i18n = 5;
+  int32 sort_order = 6;
+}
+
+message MoveTaxonomyNodeRequest {
+  string node_uuid = 1;
+  string target_parent_uuid = 2;
+  int32 sort_order = 3;
+  int64 version = 4;
+}
+
+message TaxonomyNodeResponse {
+  TaxonomyNode data = 1;
+}
+
+message DeleteTaxonomyNodeRequest {
+  string node_uuid = 1;
+}
+
+message ListTagsRequest {
+  string namespace = 1;
+  string resource_type = 2;
+  MetadataStatus status = 3;
+  string q = 4;
+  string locale = 5;
+  PaginationRequest pagination = 6;
+}
+
+message ListTagsResponse {
+  repeated Tag data = 1;
+  PaginationResponse pagination = 2;
+}
+
+message CreateTagRequest {
+  string namespace = 1;
+  string resource_type = 2;
+  string code = 3;
+  I18nMap label_i18n = 4;
+  I18nMap description_i18n = 5;
+  string color = 6;
+}
+
+message UpdateTagRequest {
+  string tag_uuid = 1;
+  I18nMap label_i18n = 2;
+  I18nMap description_i18n = 3;
+  string color = 4;
+  MetadataStatus status = 5;
+}
+
+message TagResponse {
+  Tag data = 1;
+}
+
+message MergeTagsRequest {
+  string source_tag_uuid = 1;
+  string target_tag_uuid = 2;
+}
+
+message MergeTagsResponse {
+  int64 moved_bindings = 1;
+}
+
+message DeleteTagRequest {
+  string tag_uuid = 1;
+}
+
+message ListTagBindingsRequest {
+  string resource_type = 1;
+  string resource_uuid = 2;
+  string locale = 3;
+}
+
+message ListTagBindingsResponse {
+  repeated TagBinding data = 1;
+}
+
+message ReplaceTagBindingsRequest {
+  string resource_type = 1;
+  string resource_uuid = 2;
+  repeated string tag_uuids = 3;
+}
+
+message ListResourceTypesRequest {
+  string module = 1;
+  MetadataStatus status = 2;
+  string q = 3;
+  string locale = 4;
+  PaginationRequest pagination = 5;
+}
+
+message ListResourceTypesResponse {
+  repeated ResourceType data = 1;
+  PaginationResponse pagination = 2;
+}
+
+message RegisterResourceTypeRequest {
+  string resource_type = 1;
+  string module = 2;
+  I18nMap name_i18n = 3;
+  I18nMap description_i18n = 4;
+  string validator_key = 5;
+  bool binding_enabled = 6;
+}
+
+message UpdateResourceTypeRequest {
+  string resource_type_uuid = 1;
+  I18nMap name_i18n = 2;
+  I18nMap description_i18n = 3;
+  string validator_key = 4;
+  bool binding_enabled = 5;
+  MetadataStatus status = 6;
+}
+
+message ResourceTypeResponse {
+  ResourceType data = 1;
+}
+
+message DeleteResponse {
+  bool success = 1;
+  repeated ReferenceSummary references = 2;
+}

--- a/specs/029-metadata-governance/contracts/metadata.proto
+++ b/specs/029-metadata-governance/contracts/metadata.proto
@@ -7,6 +7,7 @@ option go_package = "github.com/ArtisanCloud/PowerX/api/grpc/gen/go/powerx/metad
 service MetadataGovernanceService {
   rpc ListDictionaryNamespaces(ListDictionaryNamespacesRequest) returns (ListDictionaryNamespacesResponse);
   rpc CreateDictionaryNamespace(CreateDictionaryNamespaceRequest) returns (DictionaryNamespaceResponse);
+  rpc UpdateDictionaryNamespace(UpdateDictionaryNamespaceRequest) returns (DictionaryNamespaceResponse);
   rpc ListDictionaryItems(ListDictionaryItemsRequest) returns (ListDictionaryItemsResponse);
   rpc CreateDictionaryItem(CreateDictionaryItemRequest) returns (DictionaryItemResponse);
   rpc UpdateDictionaryItem(UpdateDictionaryItemRequest) returns (DictionaryItemResponse);
@@ -14,8 +15,10 @@ service MetadataGovernanceService {
 
   rpc ListTaxonomies(ListTaxonomiesRequest) returns (ListTaxonomiesResponse);
   rpc CreateTaxonomy(CreateTaxonomyRequest) returns (TaxonomyResponse);
+  rpc UpdateTaxonomy(UpdateTaxonomyRequest) returns (TaxonomyResponse);
   rpc ListTaxonomyNodes(ListTaxonomyNodesRequest) returns (ListTaxonomyNodesResponse);
   rpc CreateTaxonomyNode(CreateTaxonomyNodeRequest) returns (TaxonomyNodeResponse);
+  rpc UpdateTaxonomyNode(UpdateTaxonomyNodeRequest) returns (TaxonomyNodeResponse);
   rpc MoveTaxonomyNode(MoveTaxonomyNodeRequest) returns (TaxonomyNodeResponse);
   rpc DeleteTaxonomyNode(DeleteTaxonomyNodeRequest) returns (DeleteResponse);
 
@@ -172,6 +175,13 @@ message CreateDictionaryNamespaceRequest {
   I18nMap description_i18n = 4;
 }
 
+message UpdateDictionaryNamespaceRequest {
+  string namespace_uuid = 1;
+  I18nMap name_i18n = 2;
+  I18nMap description_i18n = 3;
+  optional MetadataStatus status = 4;
+}
+
 message DictionaryNamespaceResponse {
   DictionaryNamespace data = 1;
 }
@@ -201,8 +211,8 @@ message UpdateDictionaryItemRequest {
   string item_uuid = 1;
   I18nMap label_i18n = 2;
   I18nMap description_i18n = 3;
-  int32 sort_order = 4;
-  MetadataStatus status = 5;
+  optional int32 sort_order = 4;
+  optional MetadataStatus status = 5;
 }
 
 message DictionaryItemResponse {
@@ -234,6 +244,14 @@ message CreateTaxonomyRequest {
   int32 max_depth = 5;
 }
 
+message UpdateTaxonomyRequest {
+  string taxonomy_uuid = 1;
+  I18nMap name_i18n = 2;
+  I18nMap description_i18n = 3;
+  optional int32 max_depth = 4;
+  optional MetadataStatus status = 5;
+}
+
 message TaxonomyResponse {
   Taxonomy data = 1;
 }
@@ -258,10 +276,19 @@ message CreateTaxonomyNodeRequest {
   int32 sort_order = 6;
 }
 
+message UpdateTaxonomyNodeRequest {
+  string node_uuid = 1;
+  I18nMap label_i18n = 2;
+  I18nMap description_i18n = 3;
+  optional int32 sort_order = 4;
+  optional MetadataStatus status = 5;
+  int64 version = 6;
+}
+
 message MoveTaxonomyNodeRequest {
   string node_uuid = 1;
   string target_parent_uuid = 2;
-  int32 sort_order = 3;
+  optional int32 sort_order = 3;
   int64 version = 4;
 }
 
@@ -300,8 +327,8 @@ message UpdateTagRequest {
   string tag_uuid = 1;
   I18nMap label_i18n = 2;
   I18nMap description_i18n = 3;
-  string color = 4;
-  MetadataStatus status = 5;
+  optional string color = 4;
+  optional MetadataStatus status = 5;
 }
 
 message TagResponse {
@@ -363,9 +390,9 @@ message UpdateResourceTypeRequest {
   string resource_type_uuid = 1;
   I18nMap name_i18n = 2;
   I18nMap description_i18n = 3;
-  string validator_key = 4;
-  bool binding_enabled = 5;
-  MetadataStatus status = 6;
+  optional string validator_key = 4;
+  optional bool binding_enabled = 5;
+  optional MetadataStatus status = 6;
 }
 
 message ResourceTypeResponse {

--- a/specs/029-metadata-governance/data-model.md
+++ b/specs/029-metadata-governance/data-model.md
@@ -1,0 +1,296 @@
+# Data Model: Metadata Governance
+
+## Global Rules
+
+- Every business object table has a stable `uuid`.
+- Relationship tables may omit their own `uuid`, but all relationship fields reference target object UUIDs.
+- Every tenant-scoped metadata object stores `tenant_uuid`.
+- `namespace`, `code`, and `resource_type` are machine identifiers and are not i18n fields.
+- User-visible labels use `name_i18n`, `label_i18n`, and `description_i18n` JSONB maps.
+- `zh-CN` is required in MVP for all user-visible i18n maps.
+- Status values are `enabled`, `disabled`, and `archived`.
+- Hard deletion is allowed only when no protected references exist.
+
+## Dictionary Namespace
+
+Table: `metadata_dictionary_namespaces`
+
+Fields:
+
+- `uuid`: stable object UUID.
+- `tenant_uuid`: owning tenant UUID.
+- `namespace`: immutable machine identifier, for example `corex.customer.level`.
+- `module`: owning module, for example `corex.customer`.
+- `name_i18n`: JSONB map, requires `zh-CN`.
+- `description_i18n`: JSONB map, requires `zh-CN` when provided.
+- `status`: `enabled`, `disabled`, or `archived`.
+- `created_at`, `updated_at`.
+
+Indexes and constraints:
+
+- Unique: `tenant_uuid + namespace`.
+- Indexed: `tenant_uuid + module + status`.
+
+Validation:
+
+- `namespace` cannot be UUID, visible label, or free text.
+- `namespace` is immutable after creation.
+- Cannot hard delete when child items are referenced.
+
+## Dictionary Item
+
+Table: `metadata_dictionary_items`
+
+Fields:
+
+- `uuid`: stable object UUID.
+- `tenant_uuid`: owning tenant UUID.
+- `namespace_uuid`: parent dictionary namespace UUID.
+- `code`: immutable machine identifier.
+- `label_i18n`: JSONB map, requires `zh-CN`.
+- `description_i18n`: JSONB map, requires `zh-CN` when provided.
+- `sort_order`: integer ordering value.
+- `status`: `enabled`, `disabled`, or `archived`.
+- `metadata`: JSONB for non-label machine metadata.
+- `reference_count`: cached display count only, not authoritative for deletion.
+- `created_at`, `updated_at`.
+
+Indexes and constraints:
+
+- Unique: `tenant_uuid + namespace_uuid + code`.
+- Indexed: `tenant_uuid + namespace_uuid + status + sort_order`.
+
+Validation:
+
+- `code` must be lowercase snake case and immutable.
+- `enabled` items are selectable for new data.
+- `disabled` items are readable for history but not selectable for new data.
+- Hard delete requires zero authoritative references in `metadata_references`.
+
+## Taxonomy
+
+Table: `metadata_taxonomies`
+
+Fields:
+
+- `uuid`: stable object UUID.
+- `tenant_uuid`: owning tenant UUID.
+- `namespace`: immutable machine identifier.
+- `module`: owning module.
+- `name_i18n`: JSONB map, requires `zh-CN`.
+- `description_i18n`: JSONB map, requires `zh-CN` when provided.
+- `max_depth`: positive integer.
+- `status`: `enabled`, `disabled`, or `archived`.
+- `created_at`, `updated_at`.
+
+Indexes and constraints:
+
+- Unique: `tenant_uuid + namespace`.
+- Indexed: `tenant_uuid + module + status`.
+
+Validation:
+
+- `max_depth` must be >= 1.
+- `namespace` is immutable.
+
+## Taxonomy Node
+
+Table: `metadata_taxonomy_nodes`
+
+Fields:
+
+- `uuid`: stable object UUID.
+- `tenant_uuid`: owning tenant UUID.
+- `taxonomy_uuid`: parent taxonomy UUID.
+- `parent_uuid`: nullable parent node UUID.
+- `code`: immutable machine identifier.
+- `label_i18n`: JSONB map, requires `zh-CN`.
+- `description_i18n`: JSONB map, requires `zh-CN` when provided.
+- `path`: UUID path, for example `/taxonomy_uuid/root_node_uuid/child_node_uuid`.
+- `depth`: integer depth starting at 1 for root nodes.
+- `sort_order`: integer ordering value.
+- `status`: `enabled`, `disabled`, or `archived`.
+- `reference_count`: cached display count only.
+- `version`: optimistic lock integer or equivalent timestamp-based concurrency marker.
+- `created_at`, `updated_at`.
+
+Indexes and constraints:
+
+- Unique: `tenant_uuid + taxonomy_uuid + code`.
+- Unique or conflict-check: `tenant_uuid + taxonomy_uuid + parent_uuid + label_i18n_digest`.
+- Indexed: `tenant_uuid + taxonomy_uuid + parent_uuid + sort_order`.
+- Indexed: `tenant_uuid + taxonomy_uuid + path`.
+
+Validation:
+
+- Cannot move a node under itself or its descendants.
+- Move must recalculate `path` and `depth` for the node and descendants.
+- Move must reject depth > taxonomy `max_depth`.
+- Concurrent move/update conflicts fail fast and require reload.
+- Hard delete requires zero authoritative references in `metadata_references`.
+
+## Tag
+
+Table: `metadata_tags`
+
+Fields:
+
+- `uuid`: stable object UUID.
+- `tenant_uuid`: owning tenant UUID.
+- `namespace`: immutable tag namespace.
+- `resource_type`: immutable resource type string.
+- `code`: immutable machine identifier.
+- `label_i18n`: JSONB map, requires `zh-CN`.
+- `description_i18n`: JSONB map, requires `zh-CN` when provided.
+- `color`: optional visual hint.
+- `source`: `admin`, `seed`, `plugin`, or `system`.
+- `status`: `enabled`, `disabled`, or `archived`.
+- `usage_count`: cached display count only.
+- `created_at`, `updated_at`.
+
+Indexes and constraints:
+
+- Unique: `tenant_uuid + namespace + resource_type + code`.
+- Indexed: `tenant_uuid + resource_type + namespace + status`.
+
+Validation:
+
+- `color` cannot carry business semantics.
+- Merge requires same `tenant_uuid` and same `resource_type`.
+- Source tag and target tag cannot be the same.
+- Hard delete requires zero bindings in `metadata_tag_bindings`.
+
+## Tag Binding
+
+Table: `metadata_tag_bindings`
+
+Fields:
+
+- `tenant_uuid`: owning tenant UUID.
+- `tag_uuid`: referenced tag UUID.
+- `resource_type`: resource type string.
+- `resource_uuid`: target business object UUID.
+- `created_by_uuid`: member/user UUID for audit visibility.
+- `created_at`.
+
+Indexes and constraints:
+
+- Unique: `tenant_uuid + tag_uuid + resource_type + resource_uuid`.
+- Indexed: `tenant_uuid + resource_type + resource_uuid`.
+- Indexed: `tenant_uuid + tag_uuid`.
+
+Validation:
+
+- Writes require enabled `metadata_resource_types` record.
+- Writes require enabled object validator for the resource type.
+- Writes must verify target resource exists and belongs to current tenant.
+- Replace operation is transactional: remove omitted tags and add new tags as one consistency boundary.
+
+## Resource Type
+
+Table: `metadata_resource_types`
+
+Fields:
+
+- `uuid`: stable object UUID.
+- `tenant_uuid`: owning tenant UUID.
+- `resource_type`: immutable machine identifier, for example `customer.account`.
+- `module`: owning module.
+- `name_i18n`: JSONB map, requires `zh-CN`.
+- `description_i18n`: JSONB map, requires `zh-CN` when provided.
+- `validator_key`: key used by service registry to find object validator.
+- `binding_enabled`: boolean indicating whether tag binding writes are allowed.
+- `status`: `enabled`, `disabled`, or `archived`.
+- `created_at`, `updated_at`.
+
+Indexes and constraints:
+
+- Unique: `tenant_uuid + resource_type`.
+- Indexed: `tenant_uuid + module + status`.
+
+Validation:
+
+- `resource_type` is immutable.
+- `binding_enabled=true` requires an active validator registered for `validator_key`.
+- Disabling a resource type prevents new tag binding writes but existing bindings remain readable.
+
+## Metadata Reference
+
+Table: `metadata_references`
+
+Fields:
+
+- `tenant_uuid`: owning tenant UUID.
+- `metadata_type`: `dictionary_item`, `taxonomy_node`, or other explicit governed type.
+- `metadata_uuid`: referenced metadata object UUID.
+- `resource_type`: adopting business resource type.
+- `resource_uuid`: adopting business object UUID.
+- `field_name`: business field that stores the metadata reference.
+- `created_at`, `updated_at`.
+
+Indexes and constraints:
+
+- Unique: `tenant_uuid + metadata_type + metadata_uuid + resource_type + resource_uuid + field_name`.
+- Indexed: `tenant_uuid + metadata_type + metadata_uuid`.
+- Indexed: `tenant_uuid + resource_type + resource_uuid`.
+
+Validation:
+
+- Adopting modules must maintain references in the same write consistency boundary as business data.
+- Reference registration failure must fail and roll back the business write.
+- Deletion conflict checks use this table as authoritative source for dictionary items and taxonomy nodes.
+
+## Metadata Seed Definition
+
+Storage: `backend/config/metadata_governance/*.yaml`
+
+Fields:
+
+- `version`: seed schema version.
+- `module`: owner module.
+- `dictionaries`: dictionary namespaces and items.
+- `taxonomies`: taxonomies and nodes.
+- `resource_types`: resource type definitions.
+- `tags`: baseline tags.
+
+Validation:
+
+- Missing required fields fail seed before writes.
+- Seed upsert keys:
+  - Dictionary namespace: `tenant_uuid + namespace`.
+  - Dictionary item: `tenant_uuid + namespace + code`.
+  - Taxonomy: `tenant_uuid + namespace`.
+  - Taxonomy node: `tenant_uuid + taxonomy_uuid + code`.
+  - Tag: `tenant_uuid + namespace + resource_type + code`.
+  - Resource type: `tenant_uuid + resource_type`.
+
+## Capability Permission Mapping
+
+Formal capabilities:
+
+| Capability ID | Permission Code | Agent Usable | Risk |
+|----------------|-----------------|--------------|------|
+| `com.corex.metadata.dictionary.read` | `metadata.dictionary:read` | false | low |
+| `com.corex.metadata.dictionary.manage` | `metadata.dictionary:manage` | false | medium |
+| `com.corex.metadata.taxonomy.read` | `metadata.taxonomy:read` | false | low |
+| `com.corex.metadata.taxonomy.manage` | `metadata.taxonomy:manage` | false | medium |
+| `com.corex.metadata.tag.read` | `metadata.tag:read` | false | low |
+| `com.corex.metadata.tag.manage` | `metadata.tag:manage` | false | medium |
+| `com.corex.metadata.resource_type.read` | `metadata.resource_type:read` | false | low |
+| `com.corex.metadata.resource_type.manage` | `metadata.resource_type:manage` | false | medium |
+
+## State Transitions
+
+```text
+enabled -> disabled -> enabled
+enabled -> archived
+disabled -> archived
+archived -> disabled
+```
+
+Rules:
+
+- `enabled`: visible and selectable for new data.
+- `disabled`: visible for history, not selectable for new data.
+- `archived`: admin-visible only, not in ordinary selectors.
+- Hard delete is a separate operation and requires no protected references.

--- a/specs/029-metadata-governance/plan.md
+++ b/specs/029-metadata-governance/plan.md
@@ -1,0 +1,148 @@
+# Implementation Plan: Metadata Governance
+
+**Branch**: `029-metadata-governance` | **Date**: 2026-07-12 | **Spec**: [spec.md](/private/var/www/html/ArtisanCloud/X/PowerX/Core/PowerX/specs/029-metadata-governance/spec.md)
+**Input**: Feature specification from `/specs/029-metadata-governance/spec.md`
+
+## Summary
+
+Build Metadata Governance as a CoreX module that provides tenant-scoped dictionaries, taxonomies, tags, resource types, protected references, explicit seed flows, platform capability declarations, plugin consumption contracts, and a Nuxt admin page. The MVP does not migrate existing business modules; modules adopt metadata governance later through explicit mapping plans.
+
+The implementation uses normal PowerX Core paths: GORM models under `backend/pkg/corex/db/persistence/model/metadata`, repositories under `backend/pkg/corex/db/persistence/repository/metadata`, services under `backend/internal/service/metadata`, admin HTTP transport under `backend/internal/transport/http/admin/metadata`, gRPC contracts under `backend/api/grpc/contracts/powerx/metadata/v1`, and Web Admin pages under `web-admin/app/pages/settings/metadata-governance`.
+
+## Technical Context
+
+**Language/Version**: Go 1.24 for backend/CoreX services and CLIs; TypeScript with Nuxt 4/Vue 3 for Web Admin; Buf toolchain for gRPC contracts.
+**Primary Dependencies**: Gin HTTP stack, GORM, PostgreSQL JSONB, Redis only if later used for read caches, google.golang.org/grpc, Buf, Pinia/Nuxt UI, existing PowerX capability registry and IAM/RBAC services.
+**Storage**: PostgreSQL tables for metadata definitions, tag bindings, references, audit events through existing audit infrastructure; seed YAML under `backend/config/metadata_governance`.
+**Testing**: Go unit and integration tests via `go test`; HTTP contract tests under existing backend test layout; Nuxt/Vitest component/store tests where page logic is non-trivial; `make capability-check`; explicit migration/seed command verification.
+**Target Platform**: PowerX Core backend on Linux/macOS development environments and production Linux; Web Admin in existing Nuxt app.
+**Project Type**: CoreX backend + Web Admin frontend + plugin/framework contract surface.
+**Performance Goals**: Admin list APIs return p95 < 200ms for normal tenant-scoped pages; dictionary/tag selector reads support indexed filters by tenant, namespace, module, resource type, status, and q; deletion conflict checks use indexed `metadata_references`/`metadata_tag_bindings` lookups rather than scanning business tables.
+**Constraints**: No runtime startup AutoMigrate or AutoSeed; migrations run through explicit migrate flow only. Seed runs only through explicit command or tenant bootstrap hook. All business object tables have UUIDs; relationship tables may omit UUID but must reference object UUIDs. User-visible text must use i18n resources; no UUID/code as primary label. No fallback to plugin private metadata in delegated mode.
+**Scale/Scope**: MVP covers governance center, APIs, seed, capability declarations, plugin read/replace-binding contract, and admin page. Existing customer/knowledge/agent/media business modules are not migrated in this feature.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| COREX_DECLARED | PASS | Metadata governance is a CoreX module: `corex.metadata`. It is not a plugin and must not use `plugins/registry.json`. |
+| NO_PLUGIN_REGISTRY | PASS | Plugin work is framework consumption contract only; no plugin lifecycle registration is introduced. |
+| COREX_LAYOUT_MATCH | PASS | Planned paths match `internal/service`, `internal/transport/http`, `internal/transport/grpc`, `pkg/corex/db/persistence/model`, and repository layout. |
+| COREX_DUAL_TRANSPORT | PASS | REST/OpenAPI and gRPC design contracts are generated in `contracts/`; implementation must create both transports unless a later spec explicitly narrows the gRPC surface. |
+| COREX_BUF_CONFIG | PASS | gRPC implementation must use existing `backend/api/grpc/contracts/{buf.yaml,buf.gen.yaml}` and output to `backend/api/grpc/gen/go`. |
+| COREX_SERVER_WIRING | PASS | HTTP wiring goes through existing admin router; gRPC wiring goes through global server/bootstrap, not module-owned `grpc.NewServer`. |
+| COREX_MIGRATION_WIRING | PASS | Models are registered in centralized CoreX migration flow and invoked only by explicit migrate command, not backend startup. |
+| HTTP_PRESENT | PASS | REST contract and admin routes are planned under `/api/v1/admin/metadata/...`. |
+| GRPC_PRESENT | PASS | gRPC contract is planned as `powerx.metadata.v1.MetadataGovernanceService`. |
+| PROTOBUF_DEFINED | PASS | Design proto exists in `contracts/metadata.proto`; implementation must copy/adapt into authoritative `backend/api/grpc/contracts/powerx/metadata/v1/metadata.proto`. |
+| SERVER_DEFINED | PASS | Plan requires global gRPC bootstrap registration with auth/tenant/logging/recovery interceptors. |
+| MAKE_TARGETS | PASS | Plan requires `proto-gen`, `proto-lint`, `proto-clean`, `migrate`, metadata seed command, and `capability-check`. |
+| SECURITY_RBAC_AUDIT | PASS | Read/manage permissions, capability mappings, tenant isolation, and audit events are required. |
+| OBSERVABILITY | PASS | Service logs include `trace_id`, `tenant_uuid`, metadata object UUIDs, operation, and failure codes. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/029-metadata-governance/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── http-openapi.yaml
+│   └── metadata.proto
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── api/grpc/contracts/powerx/metadata/v1/
+│   └── metadata.proto
+├── api/grpc/gen/go/powerx/metadata/v1/
+├── cmd/
+│   └── metadata_seed/
+├── config/
+│   ├── metadata_governance/
+│   │   └── seed.yaml
+│   └── platform_capabilities/
+│       └── metadata.yaml
+├── internal/
+│   ├── dto/metadata/
+│   ├── service/metadata/
+│   ├── transport/grpc/metadata/
+│   └── transport/http/admin/metadata/
+├── pkg/corex/db/
+│   ├── database/migration.go
+│   └── persistence/
+│       ├── model/metadata/
+│       └── repository/metadata/
+└── internal/tests/
+    ├── http/admin/metadata/
+    └── integration/metadata/
+
+web-admin/
+├── app/pages/settings/metadata-governance/
+│   └── index.vue
+├── app/components/settings/metadata-governance/
+├── app/composables/api/metadata-governance.ts
+├── app/stores/metadata-governance.ts
+├── app/types/metadata-governance.ts
+└── i18n/locales/
+
+docs/guides/develop/
+└── metadata_governance.md
+```
+
+**Structure Decision**: Use CoreX module structure. Metadata governance is a platform domain and must be implemented in PowerX Core, not as a plugin. Plugin framework work is limited to consuming the governed contract and must not introduce plugin-managed metadata definitions in MVP.
+
+## Phase 0: Research
+
+Phase 0 output: [research.md](/private/var/www/html/ArtisanCloud/X/PowerX/Core/PowerX/specs/029-metadata-governance/research.md)
+
+Research decisions:
+
+- Metadata definitions are tenant-scoped rows, not global shared rows at runtime.
+- i18n values are JSONB maps with required `zh-CN`; admin views may show `zh-CN` with an explicit missing-locale marker when requested locale is absent.
+- Tag binding writes require an enabled resource type validator.
+- Protected reference registration is part of the consistency boundary for adopting modules.
+- Seed is explicit command or tenant bootstrap only; backend startup must not seed.
+- Capability publication uses business authorization units, not one raw route per endpoint.
+
+## Phase 1: Design & Contracts
+
+Phase 1 outputs:
+
+- [data-model.md](/private/var/www/html/ArtisanCloud/X/PowerX/Core/PowerX/specs/029-metadata-governance/data-model.md)
+- [contracts/http-openapi.yaml](/private/var/www/html/ArtisanCloud/X/PowerX/Core/PowerX/specs/029-metadata-governance/contracts/http-openapi.yaml)
+- [contracts/metadata.proto](/private/var/www/html/ArtisanCloud/X/PowerX/Core/PowerX/specs/029-metadata-governance/contracts/metadata.proto)
+- [quickstart.md](/private/var/www/html/ArtisanCloud/X/PowerX/Core/PowerX/specs/029-metadata-governance/quickstart.md)
+
+Design requirements:
+
+- REST is the management and plugin-invocation binding contract.
+- gRPC provides CoreX service parity for internal/Core consumers and generated clients.
+- Admin REST paths use `/api/v1/admin/metadata/...` and user JWT/RBAC.
+- Plugin service calls use `/api/v1/tenant/invocations` with metadata capabilities or approved service bindings, not plugin-private fallback lists.
+- Capability declarations must be added to `backend/config/platform_capabilities/metadata.yaml` and verified by `make capability-check`.
+
+## Post-Design Constitution Check
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| No unresolved clarifications | PASS | Clarifications section in `spec.md` contains 5 accepted decisions. |
+| REST + gRPC contracts present | PASS | `contracts/http-openapi.yaml` and `contracts/metadata.proto` generated. |
+| CoreX path compliance | PASS | Plan maps backend to CoreX directories and migration flow. |
+| No runtime migration/seed | PASS | Plan and quickstart require explicit migrate and seed commands. |
+| Capability governance | PASS | Plan requires `metadata.yaml`, `make capability-check`, and no direct validator-only bypass. |
+| i18n compliance | PASS | Data model and contracts require i18n maps and missing-locale marker. |
+| UUID relationship compliance | PASS | Data model uses object UUID references for all external relationships. |
+
+## Complexity Tracking
+
+No constitutional violations are introduced. The module is broad, but it is a single CoreX governance domain with four sub-areas, not four independent systems. The chosen structure avoids generic polymorphic metadata tables for definitions while still using explicit resource type registration for tag bindings and protected references.

--- a/specs/029-metadata-governance/quickstart.md
+++ b/specs/029-metadata-governance/quickstart.md
@@ -1,0 +1,175 @@
+# Quickstart: Metadata Governance
+
+## Prerequisites
+
+- Working branch: `029-metadata-governance`.
+- PostgreSQL and Redis available for normal PowerX development.
+- Backend dependencies ready for Go 1.24.
+- Web Admin dependencies installed for Nuxt 4.
+
+## Backend Development Flow
+
+1. Implement models and migration registration.
+
+   Models belong under:
+
+   ```text
+   backend/pkg/corex/db/persistence/model/metadata/
+   ```
+
+   Register them in the centralized CoreX migration flow:
+
+   ```text
+   backend/pkg/corex/db/database/migration.go
+   ```
+
+   Do not run migration from backend startup.
+
+2. Run explicit migration.
+
+   Use the repository's migration command or Make target once it exists for this branch:
+
+   ```bash
+   make migrate-up
+   ```
+
+   If the repo uses a different explicit migration command in the current branch, use that command. Do not add runtime AutoMigrate to app startup.
+
+3. Implement repository and service layers.
+
+   Required layers:
+
+   ```text
+   backend/pkg/corex/db/persistence/repository/metadata/
+   backend/internal/service/metadata/
+   backend/internal/dto/metadata/
+   ```
+
+   Service tests must cover tenant isolation, uniqueness, status transitions, deletion conflicts, tag binding validator failures, and reference registration rollback.
+
+4. Implement REST and gRPC transports.
+
+   REST:
+
+   ```text
+   backend/internal/transport/http/admin/metadata/
+   ```
+
+   gRPC:
+
+   ```text
+   backend/api/grpc/contracts/powerx/metadata/v1/metadata.proto
+   backend/internal/transport/grpc/metadata/
+   ```
+
+   Generate and validate proto:
+
+   ```bash
+   make proto-gen
+   make proto-lint
+   ```
+
+5. Add platform capability declarations.
+
+   Add:
+
+   ```text
+   backend/config/platform_capabilities/metadata.yaml
+   ```
+
+   Then verify:
+
+   ```bash
+   make capability-check
+   ```
+
+6. Add explicit metadata seed command.
+
+   Seed definitions live under:
+
+   ```text
+   backend/config/metadata_governance/
+   ```
+
+   Seed may run through:
+
+   - explicit command for development/repair;
+   - tenant bootstrap hook for new tenants.
+
+   Seed must not run from backend startup.
+
+## Web Admin Flow
+
+1. Add route and page:
+
+   ```text
+   web-admin/app/pages/settings/metadata-governance/index.vue
+   ```
+
+2. Add API composable/store/types:
+
+   ```text
+   web-admin/app/composables/api/metadata-governance.ts
+   web-admin/app/stores/metadata-governance.ts
+   web-admin/app/types/metadata-governance.ts
+   ```
+
+3. Add locale entries for every visible label, button, empty state, error, toast, validation message, and confirm message.
+
+4. Verify these page states for every tab:
+
+   - loading;
+   - no permission;
+   - missing selection;
+   - empty result;
+   - backend error;
+   - contract/capability authorization error.
+
+## Plugin/Framework Verification
+
+MVP framework contract must support:
+
+- resolve resource type;
+- list dictionary items;
+- list taxonomy nodes;
+- list tags;
+- replace tag bindings.
+
+Delegated mode must call governed PowerX metadata capabilities. It must not read plugin private defaults as fallback.
+
+Local mode must use canonical seed-derived data and fail initialization when required seed definitions are missing.
+
+## Acceptance Commands
+
+Run backend tests:
+
+```bash
+cd backend
+go test ./internal/service/metadata/... ./pkg/corex/db/persistence/repository/metadata/... ./internal/tests/http/admin/metadata/...
+```
+
+Run capability verification:
+
+```bash
+make capability-check
+```
+
+Run Web Admin tests:
+
+```bash
+cd web-admin
+npm run test
+```
+
+Manual smoke path:
+
+1. Run explicit migration.
+2. Run explicit metadata seed for a test tenant.
+3. Start backend and web-admin.
+4. Open `设置 > 元数据治理`.
+5. Create a dictionary namespace and five items.
+6. Disable one item and verify it is not selectable for new data.
+7. Create taxonomy nodes and verify invalid move is rejected.
+8. Register a resource type without validator and verify tag binding write is rejected.
+9. Register a resource type with validator and verify tag binding replace succeeds.
+10. Remove metadata permission from a user and verify manage buttons are unavailable.

--- a/specs/029-metadata-governance/research.md
+++ b/specs/029-metadata-governance/research.md
@@ -1,0 +1,92 @@
+# Research: Metadata Governance
+
+## Decision: Implement as CoreX module `corex.metadata`
+
+**Rationale**: Metadata governance is a platform authority used by CoreX modules, plugins, Agent flows, and admin pages. It must be tenant-scoped and enforced by PowerX Core RBAC/capability systems, so it belongs in CoreX rather than a plugin.
+
+**Alternatives considered**:
+
+- Plugin implementation: rejected because plugins cannot be the canonical authority for platform metadata.
+- Per-module metadata stores: rejected because it preserves the current duplication problem.
+
+## Decision: Use separate definition tables, not one generic metadata table
+
+**Rationale**: Dictionaries, taxonomies, tags, resource types, and references have different lifecycle rules, uniqueness constraints, and UI behavior. Separate tables keep validation strict and make constraints testable.
+
+**Alternatives considered**:
+
+- Single polymorphic `metadata_objects` table: rejected because it hides incompatible semantics behind generic fields and weakens indexes and validation.
+- JSON-only registry: rejected because deletion protection, filtering, and references require relational queries.
+
+## Decision: Store i18n values as JSONB maps with required `zh-CN`
+
+**Rationale**: User-visible names and descriptions must not be hard-coded or replaced by raw codes. JSONB maps allow admin editing across locales while keeping one record per metadata object.
+
+**Alternatives considered**:
+
+- Separate translation table: deferred because MVP needs simpler CRUD and admin editing; can be revisited if translation workflow grows.
+- Single-language text fields: rejected because it violates i18n requirements.
+
+## Decision: Missing requested locale is visible, not silent
+
+**Rationale**: Admin pages need to remain usable even when a locale is missing, but the absence must be explicit. APIs should return `display_locale_missing` and the UI should show a translation-missing state.
+
+**Alternatives considered**:
+
+- Fail the list API when a locale is missing: rejected because it makes admin cleanup difficult.
+- Show code or UUID as the label: rejected by UI and i18n rules.
+- Silent fallback to `zh-CN`: rejected because it hides data quality problems.
+
+## Decision: Tag binding writes require object validators
+
+**Rationale**: Tag bindings are polymorphic and cannot rely on a single DB foreign key. Without a resource type object validator, the service cannot prove the resource exists or belongs to the current tenant.
+
+**Alternatives considered**:
+
+- Validate only UUID format: rejected because it permits dangling and cross-tenant bindings.
+- Async repair invalid bindings: rejected because delete protection and usage counts become untrustworthy.
+
+## Decision: Protected references are explicit records
+
+**Rationale**: Deletion protection must not scan every business table. `metadata_references` gives a stable conflict source and reference summary for dictionary items and taxonomy nodes; tag bindings already provide direct reference records.
+
+**Alternatives considered**:
+
+- On-demand scans of business modules: rejected because it does not scale and requires module-specific coupling.
+- Reference counters only: rejected because counters are display hints, not authoritative conflict records.
+
+## Decision: Reference registration is part of adopting module write consistency
+
+**Rationale**: Once a module adopts metadata governance, business writes and reference registration must succeed or fail together. Partial success would make hard-delete protection unreliable.
+
+**Alternatives considered**:
+
+- Async reference registration: rejected for MVP because it creates deletion races.
+- Warning-only registration failures: rejected because it hides data corruption.
+
+## Decision: Seed runs only through explicit command or tenant bootstrap hook
+
+**Rationale**: Runtime startup must not create tables or seed data. Explicit command supports development/repair; tenant bootstrap hook supports new tenant provisioning.
+
+**Alternatives considered**:
+
+- Backend startup AutoSeed: rejected because it couples runtime availability to data mutation.
+- Admin page seed button: rejected for MVP because initialization is operational/bootstrap behavior, not normal metadata editing.
+
+## Decision: Capability declarations are business authorization units
+
+**Rationale**: Metadata APIs should expose read/manage boundaries for dictionary, taxonomy, tag, and resource type domains. Capabilities should not be raw route IDs. STS direct behavior must be derived from formal capability declarations and blocklist rules.
+
+**Alternatives considered**:
+
+- One capability per REST route: rejected because it creates unreadable grants and UI noise.
+- Validator-only allowlisting: rejected because it bypasses capability governance.
+
+## Decision: MVP excludes existing business module migration
+
+**Rationale**: The first release must make the governance platform usable and testable before migrating customer, knowledge, agent, media, or other module data. Each adopting module must provide a mapping and migration plan later.
+
+**Alternatives considered**:
+
+- Migrate customer module in MVP: rejected because it expands scope and mixes platform infrastructure with business data migration.
+- Migrate multiple modules: rejected due to high regression risk.

--- a/specs/029-metadata-governance/spec.md
+++ b/specs/029-metadata-governance/spec.md
@@ -1,0 +1,204 @@
+# Feature Specification: Metadata Governance
+
+**Feature Branch**: `029-metadata-governance`  
+**Created**: 2026-07-12  
+**Status**: Draft  
+**Input**: User description: "请根据 docs/plan/metadata-governance 生成对应的 spec 文档"
+
+## Clarifications
+
+### Session 2026-07-12
+
+- Q: 029-metadata-governance 的 MVP 是否包含首个业务模块迁移？ → A: 只做元数据治理中心、底座 API、权限、seed、插件消费契约；不迁移现有业务模块。
+- Q: metadata seed 的触发方式怎么定？ → A: 同时支持显式命令和租户初始化流程触发；禁止应用启动时自动 seed。
+- Q: 资源类型没有对象校验器时，是否允许写标签绑定？ → A: 不允许写入；资源类型缺少对象校验器时只能读定义，不能绑定标签。
+- Q: 当前语言缺少翻译时，后台管理页面怎么显示？ → A: 显示 zh-CN 名称，同时明确标记当前语言缺失；API 返回缺失标记。
+- Q: 引用登记失败时，业务写入怎么处理？ → A: 对已接入 metadata governance 的模块，业务写入必须失败并回滚。
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - 统一管理数据字典 (Priority: P1)
+
+作为租户管理员，我希望在统一入口管理客户来源、客户等级、任务优先级等业务枚举，以便底座、插件、Agent 和业务页面使用同一份权威定义，而不是各模块各自维护。
+
+**Why this priority**: 数据字典是最基础、最稳定的元数据治理对象。没有统一字典，后续分类、标签和插件接入都会继续产生重复定义。
+
+**Independent Test**: 管理员创建一个字典命名空间和多个字典项，业务选择器能只展示启用项；停用项不再可选但历史已选值仍可读。
+
+**Acceptance Scenarios**:
+
+1. **Given** 租户管理员进入元数据治理页面，**When** 创建一个字典命名空间并添加多个字典项，**Then** 字典项按租户隔离、按排序展示，并可按名称或 code 搜索。
+2. **Given** 一个字典项已被业务数据引用，**When** 管理员尝试删除该字典项，**Then** 系统拒绝硬删除并提示存在引用，只允许停用或先迁移引用。
+3. **Given** 一个字典项被停用，**When** 用户打开新建或编辑业务表单，**Then** 该字典项不再作为新值可选；已保存历史值仍显示原名称。
+4. **Given** 管理员编辑字典名称或描述，**When** 切换后台语言，**Then** 页面展示对应语言的名称，不把 code 或 UUID 作为主展示。
+
+---
+
+### User Story 2 - 维护可控分类体系 (Priority: P1)
+
+作为租户管理员，我希望维护知识库目录、内容类目、商品分类等层级分类，以便业务对象能使用受控层级而不是自由文本路径。
+
+**Why this priority**: 分类体系决定了内容组织和业务筛选的结构边界，需要和字典一样成为首版治理能力。
+
+**Independent Test**: 管理员创建一个分类体系、添加多级节点、移动节点并验证层级深度、环检测和引用删除保护。
+
+**Acceptance Scenarios**:
+
+1. **Given** 租户管理员创建分类体系并设置最大层级，**When** 新建根节点和子节点，**Then** 系统按层级展示节点并阻止超过最大层级的创建。
+2. **Given** 一个分类节点已有后代节点，**When** 管理员尝试把该节点移动到自己的后代下，**Then** 系统拒绝该移动并提示会形成循环。
+3. **Given** 一个分类节点已被业务对象引用，**When** 管理员尝试硬删除该节点，**Then** 系统拒绝删除并提示引用摘要。
+4. **Given** 父节点被停用，**When** 管理员保存变更，**Then** 系统提示子节点可选状态会受影响，并在业务选择器中体现停用结果。
+
+---
+
+### User Story 3 - 治理标签和标签绑定 (Priority: P1)
+
+作为租户管理员，我希望统一管理客户标签、文件标签、Agent 标签等业务标注，并查看标签使用情况，以便标签可筛选、可统计、可审计、可合并。
+
+**Why this priority**: 标签是现有系统最分散的元数据形态之一，直接影响客户、知识库、媒体和 Agent 上下文组织。
+
+**Independent Test**: 管理员注册资源类型、创建标签、给资源绑定标签、查看使用次数、合并标签，并验证审计记录。
+
+**Acceptance Scenarios**:
+
+1. **Given** 某业务对象类型已注册为可打标签资源，**When** 管理员创建该资源类型下的标签，**Then** 标签按租户、命名空间和资源类型唯一。
+2. **Given** 用户给业务对象绑定多个标签，**When** 保存绑定，**Then** 系统只接受已启用标签，并记录绑定人和绑定时间。
+3. **Given** 两个标签表达同一含义，**When** 管理员执行标签合并，**Then** 源标签的绑定转移到目标标签，合并动作写入审计。
+4. **Given** 一个标签已有绑定，**When** 管理员尝试硬删除该标签，**Then** 系统拒绝删除并提示使用次数。
+
+---
+
+### User Story 4 - 管理资源类型和引用完整性 (Priority: P2)
+
+作为平台或租户管理员，我希望所有可被标签绑定或元数据引用的业务对象先注册资源类型，以便系统能校验资源存在性、租户边界和删除保护。
+
+**Why this priority**: 标签绑定是多态关系，必须通过资源类型治理来避免无效 resource reference、跨租户绑定和不可删除数据。
+
+**Independent Test**: 注册一个资源类型后才能写入标签绑定；未配置对象校验能力的资源类型只能查看，不能写入绑定。
+
+**Acceptance Scenarios**:
+
+1. **Given** 某业务对象类型尚未注册，**When** 用户尝试给该对象写入标签绑定，**Then** 系统拒绝并提示资源类型不存在。
+2. **Given** 某资源类型已注册但不可写入绑定，**When** 用户尝试替换标签绑定，**Then** 系统拒绝并提示缺少对象校验能力。
+3. **Given** 某资源类型已启用且对象属于当前租户，**When** 用户替换标签绑定，**Then** 系统完成绑定并更新使用统计。
+4. **Given** 资源类型已有绑定数据，**When** 管理员尝试删除资源类型，**Then** 系统拒绝删除并要求先清理绑定。
+
+---
+
+### User Story 5 - 插件消费底座元数据 (Priority: P2)
+
+作为插件开发者，我希望插件通过统一客户端读取底座字典、分类、标签并替换标签绑定，以便 delegated 模式使用底座权威元数据，local 模式使用同源 seed 调试。
+
+**Why this priority**: 插件如果继续各自维护默认值，metadata governance 无法成为生态统一能力。
+
+**Independent Test**: 一个插件在 delegated 模式读取字典项和标签并替换绑定；在 local 模式缺少 seed 时启动失败。
+
+**Acceptance Scenarios**:
+
+1. **Given** 插件运行在 delegated 模式，**When** 插件请求读取某个字典命名空间，**Then** 返回当前租户启用项，不读取插件私有 fallback。
+2. **Given** 插件运行在 delegated 模式但缺少能力授权，**When** 插件请求读取或写入 metadata，**Then** 系统返回明确授权错误。
+3. **Given** 插件运行在 local 模式且 canonical seed 缺失，**When** 插件初始化 metadata client，**Then** 初始化失败，不返回空列表或默认假数据。
+4. **Given** 插件需要创建或管理字典、分类、标签，**When** 插件后台尝试用服务身份绕过管理权限，**Then** 系统拒绝该管理写入。
+
+---
+
+### User Story 6 - 元数据治理管理页面可用 (Priority: P2)
+
+作为后台管理员，我希望在一个页面中按数据字典、分类体系、标签、资源类型分区管理元数据，并清楚区分无数据、无权限、未选择和加载错误。
+
+**Why this priority**: 治理能力必须有可操作页面，否则只能依赖开发人员或脚本维护，无法成为日常运营工具。
+
+**Independent Test**: 管理员进入元数据治理页面，分别操作四个 tab，验证筛选、空态、错误态、权限按钮和多语言展示。
+
+**Acceptance Scenarios**:
+
+1. **Given** 管理员拥有查看权限，**When** 进入元数据治理页面，**Then** 系统显示数据字典、分类体系、标签、资源类型四个分区。
+2. **Given** 当前未选择命名空间或资源类型，**When** 页面需要展示右侧列表，**Then** 显示“未选择”状态而不是空列表。
+3. **Given** 用户只有查看权限没有管理权限，**When** 页面渲染操作区，**Then** 管理按钮不可见或不可用。
+4. **Given** 后端返回契约错误或授权错误，**When** 页面加载失败，**Then** 页面显示明确错误状态，不渲染成“暂无数据”。
+
+### Edge Cases
+
+- 字典命名空间、分类体系、标签 namespace 或资源类型重名时，系统必须按租户边界拒绝重复创建。
+- 多语言字段缺少必填语言时，创建或更新必须失败。
+- 请求语言没有对应翻译时，系统不得把 code 当作主名称静默展示；后台管理页面可显示 zh-CN 名称但必须明确标记当前语言缺失。
+- 用户尝试使用 UUID、用户可见文案或自由文本作为 namespace/code/resource type 时，系统必须拒绝。
+- 分类节点移动过程中发生并发修改时，系统必须拒绝保存并提示刷新最新树。
+- 标签合并时源标签和目标标签相同，或跨资源类型合并，系统必须拒绝。
+- 业务对象删除、归档或迁移时，引用登记必须同步变化；同步失败时业务写入不得部分成功。
+- 已接入 metadata governance 的业务模块写入元数据引用时，引用登记失败必须导致业务写入失败并回滚。
+- root/support 跨租户查看必须走独立入口，不得复用普通租户管理入口。
+- 对外 web、mini-app、customer 场景不得复用后台 metadata 管理路径。
+- 历史业务表中已有私有 tags 或字典值时，首版不自动回填；接入模块必须提交迁移说明后再迁移。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a single metadata governance area for dictionary namespaces/items, taxonomies/nodes, tags/bindings, and resource types.
+- **FR-002**: System MUST keep dictionary, taxonomy, tag, and resource type definitions tenant-scoped and prevent cross-tenant reads or writes through tenant administration flows.
+- **FR-003**: System MUST require stable machine identifiers for namespace, code, and resource type, and MUST reject UUIDs or user-visible labels used as those identifiers.
+- **FR-004**: System MUST store and expose user-visible metadata names and descriptions as multilingual values with a required primary language for the first release.
+- **FR-005**: System MUST expose locale-specific display names while preserving the original multilingual values for administrators.
+- **FR-006**: System MUST prevent silent fallback that displays code, UUID, or technical identifiers as the primary human-facing label when a required translation is missing.
+- **FR-006a**: System MAY expose the required primary-language display name in administrator views when the requested locale is missing, but MUST return an explicit missing-locale marker so the UI can show a visible translation-missing state.
+- **FR-007**: System MUST support dictionary namespace and item creation, editing, listing, enablement, disablement, archiving, and deletion only when no protected references exist.
+- **FR-008**: System MUST treat dictionary namespace and item codes as immutable after creation.
+- **FR-009**: System MUST support taxonomy creation, node creation, node editing, enablement, disablement, archiving, deletion protection, and node movement.
+- **FR-010**: System MUST enforce taxonomy maximum depth and prevent circular hierarchy moves.
+- **FR-011**: System MUST preserve historical readability for disabled dictionary items, taxonomy nodes, and tags while preventing their use in new selections.
+- **FR-012**: System MUST require resource type registration before tags can be bound to a business object type.
+- **FR-013**: System MUST reject tag binding writes when the resource type is disabled, missing, or cannot verify the target resource belongs to the current tenant.
+- **FR-013a**: System MUST reject tag binding writes when the resource type does not have an enabled object validator; read-only resource type definitions remain listable.
+- **FR-014**: System MUST support tag creation, editing, enablement, disablement, archiving, deletion protection, and merge operations.
+- **FR-015**: System MUST record auditable events for metadata creation, update, disablement, archiving, deletion, merge, and binding changes.
+- **FR-016**: System MUST maintain protected reference records for dictionary items, taxonomy nodes, and tag bindings so deletion conflicts can be detected without scanning every business table.
+- **FR-016a**: System MUST make metadata reference registration part of the write consistency boundary for business modules that adopt metadata governance; registration failure MUST fail and roll back the business write.
+- **FR-017**: System MUST reject hard deletion of referenced metadata and return a stable conflict response with a reference summary.
+- **FR-018**: System MUST distinguish empty data, missing selection, insufficient permission, loading, and backend error states in the management experience.
+- **FR-019**: System MUST control page visibility and management actions with separate read and manage permissions for dictionaries, taxonomies, tags, and resource types.
+- **FR-020**: System MUST define capability-to-permission mappings for dictionary, taxonomy, tag, and resource type read/manage operations.
+- **FR-021**: System MUST allow plugins in delegated mode to read dictionary items, read taxonomy nodes, read tags, resolve resource types, and replace tag bindings only through the governed metadata contract.
+- **FR-022**: System MUST prevent plugin service identities from creating or managing dictionary namespaces, dictionary items, taxonomy nodes, tags, or resource types unless they use an authorized administrator path.
+- **FR-023**: System MUST provide metadata seed through an explicit command for development/repair flows and a tenant initialization hook for new tenant bootstrap; application runtime startup MUST NOT create or seed metadata.
+- **FR-024**: System MUST fail tenant initialization or local plugin metadata initialization when required seed definitions are missing or invalid.
+- **FR-025**: System MUST expose enough filtering for administrators to find metadata by namespace, module, resource type, status, and text search.
+- **FR-026**: System MUST require every business module that adopts metadata governance to provide a mapping plan for fields, namespaces, resource types, historical value handling, and reference registration.
+- **FR-027**: System MUST keep external consumer interfaces for web, mini-app, and customer scenarios out of the first release scope.
+- **FR-028**: System MUST produce a clear error when metadata objects are missing instead of accepting deprecated names, inferring namespaces from free text, or returning empty fallback lists.
+
+### Key Entities
+
+- **Dictionary Namespace**: Tenant-scoped grouping for a business enumeration, identified by stable namespace and module, with multilingual name and status.
+- **Dictionary Item**: Tenant-scoped option inside a dictionary namespace, identified by stable code, multilingual label, sort order, status, and reference state.
+- **Taxonomy**: Tenant-scoped hierarchical classification system, identified by stable namespace, module, multilingual name, maximum depth, and status.
+- **Taxonomy Node**: Node within a taxonomy tree, identified by stable code and object UUID, with parent relationship, depth, path, multilingual label, sort order, status, and reference state.
+- **Tag**: Tenant-scoped label for a resource type and namespace, identified by stable code, multilingual label, optional color, source, status, and usage state.
+- **Tag Binding**: Relationship between a tag and a business object resource, scoped by tenant, resource type, resource UUID, and creator.
+- **Resource Type**: Registered business object type that may participate in metadata binding, with module, multilingual name, status, and binding eligibility.
+- **Metadata Reference**: Protected reference record connecting a metadata object to a business object field, used for deletion protection and reference summaries.
+- **Metadata Seed Definition**: Canonical definition used to instantiate baseline dictionaries, taxonomies, tags, and resource types for a tenant or local plugin development.
+- **Capability Permission Mapping**: Governance mapping that connects a metadata capability to the permission required for user, plugin, or Agent use.
+
+### Assumptions
+
+- The first release focuses on tenant administration and plugin consumption; public web, mini-app, and customer-facing metadata APIs are out of scope.
+- Existing business modules will not be migrated in this feature; each module will adopt metadata governance through a later mapping and migration plan.
+- Multilingual values require `zh-CN` in the first release, while other supported locales may be added by administrators.
+- Plugins can consume metadata and replace tag bindings in delegated mode, but plugin service identity cannot manage metadata definitions.
+- Seed execution is explicit and observable through command or tenant bootstrap flows; application startup does not perform hidden metadata seeding.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An administrator can create a dictionary namespace with five items, disable one item, and verify the disabled item is unavailable for new selection within 5 minutes.
+- **SC-002**: An administrator can create a taxonomy with at least three levels and successfully move a node while the system blocks invalid circular moves in 100% of tested cases.
+- **SC-003**: An administrator can create tags, bind them to a registered resource, and complete a tag merge with an audit record visible for the merge action.
+- **SC-004**: 100% of attempted hard deletions for referenced dictionary items, taxonomy nodes, or tags are rejected with a conflict response and reference summary.
+- **SC-005**: Users without manage permission can view permitted metadata but cannot see or execute management actions in all metadata governance tabs.
+- **SC-006**: Locale switching displays translated metadata names for all records that provide that locale, and missing required primary-language labels block create/update operations.
+- **SC-007**: A delegated plugin can read dictionary items, taxonomy nodes, and tags for its tenant and receives a clear authorization error when its permission is missing.
+- **SC-008**: Local plugin metadata initialization fails clearly when canonical seed definitions are absent or invalid.
+- **SC-009**: Administrators can distinguish “not selected,” “no data,” “no permission,” “loading,” and “error” states in each governance tab during acceptance testing.
+- **SC-010**: No metadata governance acceptance test requires users to copy or use UUIDs as the primary visible label.

--- a/specs/029-metadata-governance/spec.md
+++ b/specs/029-metadata-governance/spec.md
@@ -166,6 +166,7 @@
 - **FR-026**: System MUST require every business module that adopts metadata governance to provide a mapping plan for fields, namespaces, resource types, historical value handling, and reference registration.
 - **FR-027**: System MUST keep external consumer interfaces for web, mini-app, and customer scenarios out of the first release scope.
 - **FR-028**: System MUST produce a clear error when metadata objects are missing instead of accepting deprecated names, inferring namespaces from free text, or returning empty fallback lists.
+- **FR-029**: System MUST preserve PATCH/update field presence across REST and gRPC contracts; gRPC update requests MUST use explicit presence semantics such as `optional` scalar fields or field masks for booleans, numeric values, enums, and strings that can be intentionally set to false, zero, disabled, archived, or empty.
 
 ### Key Entities
 

--- a/specs/029-metadata-governance/tasks.md
+++ b/specs/029-metadata-governance/tasks.md
@@ -53,6 +53,7 @@
 - [ ] T018 [P] Implement shared error codes in `backend/internal/service/metadata/errors.go` and HTTP error mapping in `backend/internal/transport/http/admin/metadata/error_mapping.go`.
 - [ ] T019 Implement admin HTTP router skeleton in `backend/internal/transport/http/admin/metadata/api.go` and mount it from the existing admin router entrypoint.
 - [ ] T020 Implement gRPC service skeleton in `backend/internal/transport/grpc/metadata/server.go` and wire it through the global gRPC bootstrap without creating a module-owned gRPC server.
+- [ ] T020a Add contract parity checks ensuring every REST PATCH/update operation has a matching gRPC Update RPC and gRPC update scalar fields preserve explicit presence for false, zero, disabled, archived, and empty values.
 - [ ] T021 Add metadata permissions to IAM seed/config path used for platform permissions, including `metadata.dictionary:read/manage`, `metadata.taxonomy:read/manage`, `metadata.tag:read/manage`, and `metadata.resource_type:read/manage`.
 - [ ] T022 Add platform capability metadata in `backend/config/platform_capabilities/metadata.yaml` with `permission_code`, `agent_usable: false`, `risk_level`, `actor_context`, `resource_scope`, and no default `sts_direct: true` for admin-user bindings.
 - [ ] T023 Add explicit seed command entrypoint `backend/cmd/metadata_seed/main.go` that validates seed files and requires explicit tenant/bootstrap input; fail fast when required seed definitions are missing.

--- a/specs/029-metadata-governance/tasks.md
+++ b/specs/029-metadata-governance/tasks.md
@@ -1,0 +1,353 @@
+# Tasks: Metadata Governance
+
+**Input**: Design documents from `/specs/029-metadata-governance/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: Included because `spec.md`, `plan.md`, and `quickstart.md` explicitly require service/repository/HTTP/Web Admin verification.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and tested independently after the foundational phase.
+
+## Format: `[ID] [P] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no dependency on another task in the same phase.
+- **[Story]**: User story label from `spec.md`.
+- Every task names concrete files or directories.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the CoreX metadata-governance skeleton, contracts, and configuration locations.
+
+- [ ] T001 Create backend metadata package directories: `backend/pkg/corex/db/persistence/model/metadata/`, `backend/pkg/corex/db/persistence/repository/metadata/`, `backend/internal/dto/metadata/`, `backend/internal/service/metadata/`, `backend/internal/transport/http/admin/metadata/`, `backend/internal/transport/grpc/metadata/`.
+- [ ] T002 Create Web Admin metadata-governance directories: `web-admin/app/pages/settings/metadata-governance/`, `web-admin/app/components/settings/metadata-governance/`, `web-admin/app/composables/api/`, `web-admin/app/stores/`, `web-admin/app/types/metadata-governance.ts`.
+- [ ] T003 [P] Copy/adapt the design proto from `specs/029-metadata-governance/contracts/metadata.proto` to authoritative `backend/api/grpc/contracts/powerx/metadata/v1/metadata.proto`.
+- [ ] T004 [P] Add canonical seed directory and placeholder schema file in `backend/config/metadata_governance/seed.schema.yaml` and initial seed file in `backend/config/metadata_governance/seed.yaml`.
+- [ ] T005 [P] Add metadata capability declaration file `backend/config/platform_capabilities/metadata.yaml` with the eight capability IDs and permission codes from `data-model.md`.
+- [ ] T006 [P] Add developer guide stub `docs/guides/develop/metadata_governance.md` linking to `specs/029-metadata-governance/{spec.md,plan.md,data-model.md,quickstart.md}`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure required before any user story can work.
+
+**CRITICAL**: No user story implementation should start until this phase is complete.
+
+### Tests First
+
+- [ ] T007 [P] Add repository migration/model test skeleton in `backend/pkg/corex/db/persistence/model/metadata/metadata_models_test.go` covering UUID fields, JSONB i18n fields, and unique index expectations.
+- [ ] T008 [P] Add service validation test skeleton in `backend/internal/service/metadata/validation_test.go` covering invalid namespace/code/resource_type, missing `zh-CN`, and forbidden UUID-as-code cases.
+- [ ] T009 [P] Add HTTP route contract test skeleton in `backend/internal/tests/http/admin/metadata/routes_test.go` asserting `/api/v1/admin/metadata/*` routes exist and require authenticated tenant context.
+
+### Implementation
+
+- [ ] T010 [P] Implement shared metadata model constants and status enums in `backend/pkg/corex/db/persistence/model/metadata/types.go`.
+- [ ] T011 Implement GORM models for dictionary namespace/item, taxonomy/node, tag/binding, resource type, and reference in `backend/pkg/corex/db/persistence/model/metadata/models.go`.
+- [ ] T012 Register metadata models in centralized migration flow in `backend/pkg/corex/db/database/migration.go`; do not add startup AutoMigrate.
+- [ ] T013 [P] Implement shared DTO types for i18n maps, display fields, pagination filters, status, and reference summaries in `backend/internal/dto/metadata/common.go`.
+- [ ] T014 [P] Implement metadata validation helpers in `backend/internal/service/metadata/validation.go` for machine identifiers, required locale, status transitions, and UUID rejection.
+- [ ] T015 [P] Implement repository base and query filter structs in `backend/pkg/corex/db/persistence/repository/metadata/repository.go`.
+- [ ] T016 Implement service constructor and dependency struct in `backend/internal/service/metadata/service.go`, depending on DB, transaction helper, audit publisher, permission checker, and resource validator registry.
+- [ ] T017 [P] Implement resource validator registry interface in `backend/internal/service/metadata/resource_validator.go`.
+- [ ] T018 [P] Implement shared error codes in `backend/internal/service/metadata/errors.go` and HTTP error mapping in `backend/internal/transport/http/admin/metadata/error_mapping.go`.
+- [ ] T019 Implement admin HTTP router skeleton in `backend/internal/transport/http/admin/metadata/api.go` and mount it from the existing admin router entrypoint.
+- [ ] T020 Implement gRPC service skeleton in `backend/internal/transport/grpc/metadata/server.go` and wire it through the global gRPC bootstrap without creating a module-owned gRPC server.
+- [ ] T021 Add metadata permissions to IAM seed/config path used for platform permissions, including `metadata.dictionary:read/manage`, `metadata.taxonomy:read/manage`, `metadata.tag:read/manage`, and `metadata.resource_type:read/manage`.
+- [ ] T022 Add platform capability metadata in `backend/config/platform_capabilities/metadata.yaml` with `permission_code`, `agent_usable: false`, `risk_level`, `actor_context`, `resource_scope`, and no default `sts_direct: true` for admin-user bindings.
+- [ ] T023 Add explicit seed command entrypoint `backend/cmd/metadata_seed/main.go` that validates seed files and requires explicit tenant/bootstrap input; fail fast when required seed definitions are missing.
+- [ ] T024 Add Make targets for explicit seed and validation in `make_files/metadata.mk` and include it from the root `Makefile`; do not alias seed to backend startup.
+
+**Checkpoint**: Foundation ready. Models migrate only through explicit migration, seed is explicit, routes/contracts are mounted, and story work can proceed.
+
+---
+
+## Phase 3: User Story 1 - 统一管理数据字典 (Priority: P1) MVP
+
+**Goal**: Tenant administrators can create dictionary namespaces/items, list/filter them, disable items, preserve historical readability, and block deletion when references exist.
+
+**Independent Test**: Create one namespace with five items, disable one item, confirm it is unavailable for new selection but still readable, and verify referenced item deletion returns conflict with reference summary.
+
+### Tests for User Story 1
+
+- [ ] T025 [P] [US1] Add repository tests for dictionary namespace/item uniqueness, tenant isolation, status filters, and sort order in `backend/pkg/corex/db/persistence/repository/metadata/dictionary_repository_test.go`.
+- [ ] T026 [P] [US1] Add service tests for dictionary create/update/list/disable/delete conflict in `backend/internal/service/metadata/dictionary_service_test.go`.
+- [ ] T027 [P] [US1] Add HTTP contract tests for dictionary endpoints in `backend/internal/tests/http/admin/metadata/dictionary_http_test.go`.
+
+### Implementation for User Story 1
+
+- [ ] T028 [P] [US1] Implement dictionary DTOs in `backend/internal/dto/metadata/dictionary.go` matching `contracts/http-openapi.yaml`.
+- [ ] T029 [US1] Implement dictionary repository methods in `backend/pkg/corex/db/persistence/repository/metadata/dictionary_repository.go`.
+- [ ] T030 [US1] Implement dictionary service methods in `backend/internal/service/metadata/dictionary_service.go` including immutable namespace/code validation and protected-reference delete checks.
+- [ ] T031 [US1] Implement dictionary HTTP handlers in `backend/internal/transport/http/admin/metadata/dictionary_handler.go` using unified PowerX response helpers.
+- [ ] T032 [US1] Implement dictionary gRPC methods in `backend/internal/transport/grpc/metadata/dictionary_server.go`.
+- [ ] T033 [US1] Add dictionary capability bindings to `backend/config/platform_capabilities/metadata.yaml` for list/create/update/delete REST routes under `com.corex.metadata.dictionary.read/manage`.
+- [ ] T034 [US1] Add dictionary seed parsing/upsert support in `backend/internal/service/metadata/seed_dictionary.go`.
+
+**Checkpoint**: US1 works independently through service, REST, gRPC, and explicit seed.
+
+---
+
+## Phase 4: User Story 2 - 维护可控分类体系 (Priority: P1)
+
+**Goal**: Tenant administrators can manage taxonomies and taxonomy nodes, enforce max depth, move nodes safely, and block circular or referenced deletes.
+
+**Independent Test**: Create a taxonomy with at least three levels, move a node successfully, verify circular move and max-depth violation fail, and verify referenced node deletion returns conflict.
+
+### Tests for User Story 2
+
+- [ ] T035 [P] [US2] Add repository tests for taxonomy/node tree queries, path/depth persistence, and tenant isolation in `backend/pkg/corex/db/persistence/repository/metadata/taxonomy_repository_test.go`.
+- [ ] T036 [P] [US2] Add service tests for taxonomy node create/move/max-depth/circular/concurrency/delete-conflict in `backend/internal/service/metadata/taxonomy_service_test.go`.
+- [ ] T037 [P] [US2] Add HTTP contract tests for taxonomy endpoints in `backend/internal/tests/http/admin/metadata/taxonomy_http_test.go`.
+
+### Implementation for User Story 2
+
+- [ ] T038 [P] [US2] Implement taxonomy DTOs in `backend/internal/dto/metadata/taxonomy.go` matching `contracts/http-openapi.yaml`.
+- [ ] T039 [US2] Implement taxonomy repository methods in `backend/pkg/corex/db/persistence/repository/metadata/taxonomy_repository.go`.
+- [ ] T040 [US2] Implement taxonomy service methods in `backend/internal/service/metadata/taxonomy_service.go`, including path/depth recalculation and optimistic concurrency validation.
+- [ ] T041 [US2] Implement taxonomy HTTP handlers in `backend/internal/transport/http/admin/metadata/taxonomy_handler.go`.
+- [ ] T042 [US2] Implement taxonomy gRPC methods in `backend/internal/transport/grpc/metadata/taxonomy_server.go`.
+- [ ] T043 [US2] Add taxonomy capability bindings to `backend/config/platform_capabilities/metadata.yaml` for read/manage REST routes.
+- [ ] T044 [US2] Add taxonomy seed parsing/upsert support in `backend/internal/service/metadata/seed_taxonomy.go`.
+
+**Checkpoint**: US2 works independently and does not require business module migration.
+
+---
+
+## Phase 5: User Story 3 - 治理标签和标签绑定 (Priority: P1)
+
+**Goal**: Tenant administrators can create tags per resource type, replace bindings, view usage, merge tags, audit changes, and block deletion of bound tags.
+
+**Independent Test**: Register a bindable resource type, create tags, bind tags to a resource, merge two tags, verify audit event, and verify bound tag deletion is rejected.
+
+### Tests for User Story 3
+
+- [ ] T045 [P] [US3] Add repository tests for tag uniqueness, binding replace, usage counts, and delete conflict in `backend/pkg/corex/db/persistence/repository/metadata/tag_repository_test.go`.
+- [ ] T046 [P] [US3] Add service tests for tag create/update/merge/delete and binding replace with enabled-only tags in `backend/internal/service/metadata/tag_service_test.go`.
+- [ ] T047 [P] [US3] Add HTTP contract tests for tag and tag-binding endpoints in `backend/internal/tests/http/admin/metadata/tag_http_test.go`.
+
+### Implementation for User Story 3
+
+- [ ] T048 [P] [US3] Implement tag DTOs in `backend/internal/dto/metadata/tag.go` and tag binding DTOs in `backend/internal/dto/metadata/tag_binding.go`.
+- [ ] T049 [US3] Implement tag repository methods in `backend/pkg/corex/db/persistence/repository/metadata/tag_repository.go`.
+- [ ] T050 [US3] Implement tag binding repository methods in `backend/pkg/corex/db/persistence/repository/metadata/tag_binding_repository.go`.
+- [ ] T051 [US3] Implement tag service methods in `backend/internal/service/metadata/tag_service.go`, including merge, audit hooks, delete protection, and enabled-only binding validation.
+- [ ] T052 [US3] Implement tag binding service methods in `backend/internal/service/metadata/tag_binding_service.go`, including transactional replace.
+- [ ] T053 [US3] Implement tag HTTP handlers in `backend/internal/transport/http/admin/metadata/tag_handler.go` and tag binding handlers in `backend/internal/transport/http/admin/metadata/tag_binding_handler.go`.
+- [ ] T054 [US3] Implement tag gRPC methods in `backend/internal/transport/grpc/metadata/tag_server.go`.
+- [ ] T055 [US3] Add tag capability bindings to `backend/config/platform_capabilities/metadata.yaml` for read/manage REST routes.
+- [ ] T056 [US3] Add tag seed parsing/upsert support in `backend/internal/service/metadata/seed_tag.go`.
+
+**Checkpoint**: US3 works independently when a resource validator is registered.
+
+---
+
+## Phase 6: User Story 4 - 管理资源类型和引用完整性 (Priority: P2)
+
+**Goal**: Platform or tenant administrators can register resource types and the system can validate resource existence, tenant boundary, and protected references.
+
+**Independent Test**: Register a resource type without validator and verify tag binding write fails; register one with validator and verify binding succeeds; verify metadata reference registration rollback behavior.
+
+### Tests for User Story 4
+
+- [ ] T057 [P] [US4] Add repository tests for resource type and metadata reference uniqueness/index behavior in `backend/pkg/corex/db/persistence/repository/metadata/resource_reference_repository_test.go`.
+- [ ] T058 [P] [US4] Add service tests for resource type registration, missing validator write rejection, enabled validator success, and reference rollback in `backend/internal/service/metadata/resource_reference_service_test.go`.
+- [ ] T059 [P] [US4] Add HTTP contract tests for resource type endpoints in `backend/internal/tests/http/admin/metadata/resource_type_http_test.go`.
+
+### Implementation for User Story 4
+
+- [ ] T060 [P] [US4] Implement resource type DTOs in `backend/internal/dto/metadata/resource_type.go` and reference DTOs in `backend/internal/dto/metadata/reference.go`.
+- [ ] T061 [US4] Implement resource type repository in `backend/pkg/corex/db/persistence/repository/metadata/resource_type_repository.go`.
+- [ ] T062 [US4] Implement metadata reference repository in `backend/pkg/corex/db/persistence/repository/metadata/reference_repository.go`.
+- [ ] T063 [US4] Implement resource type service in `backend/internal/service/metadata/resource_type_service.go`, including validator status resolution and immutable `resource_type` enforcement.
+- [ ] T064 [US4] Implement metadata reference service in `backend/internal/service/metadata/reference_service.go` with transactional register/replace/delete helpers for adopting modules.
+- [ ] T065 [US4] Integrate `ResourceValidatorRegistry` into `backend/internal/service/metadata/tag_binding_service.go` so writes fail when validator is missing or disabled.
+- [ ] T066 [US4] Implement resource type HTTP handlers in `backend/internal/transport/http/admin/metadata/resource_type_handler.go`.
+- [ ] T067 [US4] Implement resource type gRPC methods in `backend/internal/transport/grpc/metadata/resource_type_server.go`.
+- [ ] T068 [US4] Add resource type capability bindings to `backend/config/platform_capabilities/metadata.yaml`.
+
+**Checkpoint**: US4 provides the integrity layer required by plugin/framework tag binding writes.
+
+---
+
+## Phase 7: User Story 5 - 插件消费底座元数据 (Priority: P2)
+
+**Goal**: Plugins can consume governed metadata through framework/client contracts in delegated mode and fail clearly in local mode when canonical seed is missing.
+
+**Independent Test**: A plugin-style client reads dictionary items, taxonomy nodes, tags, resolves resource type, and replaces tag bindings through governed capability paths; missing capability or missing local seed fails explicitly.
+
+### Tests for User Story 5
+
+- [ ] T069 [P] [US5] Add delegated metadata client tests in `backend/internal/tests/integration/metadata/plugin_metadata_client_test.go` covering read and replace-binding capability paths.
+- [ ] T070 [P] [US5] Add seed failure tests in `backend/internal/service/metadata/seed_service_test.go` for missing canonical definitions and invalid schema.
+- [ ] T071 [P] [US5] Add capability registry verification test in `backend/internal/tests/integration/metadata/metadata_capability_test.go` for missing permission and successful tenant registration.
+
+### Implementation for User Story 5
+
+- [ ] T072 [US5] Implement metadata seed loader and schema validator in `backend/internal/service/metadata/seed_loader.go`.
+- [ ] T073 [US5] Implement seed service orchestration in `backend/internal/service/metadata/seed_service.go` for explicit command and tenant bootstrap hook entrypoints.
+- [ ] T074 [US5] Wire `backend/cmd/metadata_seed/main.go` to `seed_service.go` with required tenant UUID and dry-run flags.
+- [ ] T075 [US5] Add tenant bootstrap integration point for metadata seed in the tenant provisioning service path, ensuring failures abort bootstrap and do not run at backend startup.
+- [ ] T076 [US5] Add metadata capability entries to capability required/audit config if needed in `backend/config/capability_audit_required.yaml`.
+- [ ] T077 [US5] Run `make capability-gen` and adjust `backend/config/platform_capabilities/metadata.yaml` or audit ignore entries so `make capability-check` passes without opening unmanaged admin STS direct paths.
+- [ ] T078 [US5] Document plugin framework metadata client contract in `docs/guides/develop/plugin_agent_skill_bridge.md` and `docs/guides/develop/metadata_governance.md`, including delegated/local behavior and no private fallback rule.
+
+**Checkpoint**: US5 is consumable by plugin teams without requiring business module migration.
+
+---
+
+## Phase 8: User Story 6 - 元数据治理管理页面可用 (Priority: P2)
+
+**Goal**: Admin users can manage dictionaries, taxonomies, tags, and resource types in one settings page with clear loading, no-permission, missing-selection, empty, and error states.
+
+**Independent Test**: Open `设置 > 元数据治理`, operate each tab, verify filters, permissions, i18n labels, missing locale markers, and differentiated empty/error states.
+
+### Tests for User Story 6
+
+- [ ] T079 [P] [US6] Add store/composable tests for metadata API state handling in `web-admin/app/stores/metadata-governance.test.ts`.
+- [ ] T080 [P] [US6] Add page component tests for tab empty/no-permission/loading/error/missing-selection states in `web-admin/app/pages/settings/metadata-governance/index.test.ts`.
+
+### Implementation for User Story 6
+
+- [ ] T081 [P] [US6] Implement Web Admin TypeScript types in `web-admin/app/types/metadata-governance.ts` matching `contracts/http-openapi.yaml`.
+- [ ] T082 [P] [US6] Implement API composable in `web-admin/app/composables/api/metadata-governance.ts` without hard-coded user-visible copy.
+- [ ] T083 [US6] Implement Pinia store in `web-admin/app/stores/metadata-governance.ts` with separate states for loading, no permission, missing selection, empty data, and backend error.
+- [ ] T084 [P] [US6] Add reusable state and filter components under `web-admin/app/components/settings/metadata-governance/`.
+- [ ] T085 [US6] Implement settings page `web-admin/app/pages/settings/metadata-governance/index.vue` with tabs for dictionaries, taxonomies, tags, and resource types.
+- [ ] T086 [US6] Add settings menu/route entry for metadata governance using existing settings navigation files.
+- [ ] T087 [US6] Add locale keys for all page labels, buttons, validation messages, empty states, toasts, and confirmations in `web-admin/i18n/locales/zh-CN.json` and supported locale files.
+- [ ] T088 [US6] Add UI permission checks so read permissions show tabs and manage permissions control create/edit/delete/merge actions.
+- [ ] T089 [US6] Add missing-locale visual marker support in page rows and forms when API returns `display_locale_missing=true`.
+
+**Checkpoint**: US6 provides the operational UI for the completed backend metadata governance surface.
+
+---
+
+## Final Phase: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation, documentation, observability, and release readiness across all stories.
+
+- [ ] T090 [P] Add structured logs for metadata operations in `backend/internal/service/metadata/*.go` with `trace_id`, `tenant_uuid`, operation, object UUID, and stable error code.
+- [ ] T091 [P] Add audit event integration for create/update/disable/archive/delete/merge/binding changes in `backend/internal/service/metadata/audit.go`.
+- [ ] T092 [P] Update `docs/guides/develop/open_capability/readme.md` with metadata capability discovery and invocation examples.
+- [ ] T093 [P] Update `docs/plan/metadata-governance/{README.md,mechanisms.md,pages.md,rules.md}` if implementation decisions differ from the generated spec artifacts.
+- [ ] T094 Run `make proto-gen` and `make proto-lint`; commit generated files under `backend/api/grpc/gen/go/powerx/metadata/v1/`.
+- [ ] T095 Run explicit migration verification using the repository's migration command; confirm no backend startup AutoMigrate/AutoSeed was added.
+- [ ] T096 Run backend tests: `cd backend && go test ./internal/service/metadata/... ./pkg/corex/db/persistence/repository/metadata/... ./internal/tests/http/admin/metadata/... ./internal/tests/integration/metadata/...`.
+- [ ] T097 Run `make capability-check` and fix capability declarations, generated raw capabilities, or audit ignore entries until it passes.
+- [ ] T098 Run Web Admin tests: `cd web-admin && npm run test`.
+- [ ] T099 Run manual quickstart smoke path from `specs/029-metadata-governance/quickstart.md` and record any deviations in `docs/guides/develop/metadata_governance.md`.
+- [ ] T100 Review all new user-visible text for i18n compliance and all API/DTO/event references for UUID-only business object references.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup**: No dependencies.
+- **Phase 2 Foundational**: Depends on Phase 1. Blocks every user story.
+- **US1 Dictionaries**: Depends on Phase 2.
+- **US2 Taxonomies**: Depends on Phase 2.
+- **US3 Tags/Bindings**: Depends on Phase 2 and uses the resource validator abstraction from T017; full binding success path depends on US4 resource type implementation.
+- **US4 Resource Types/References**: Depends on Phase 2; unlocks strict tag binding writes.
+- **US5 Plugin Consumption/Seed**: Depends on US1, US2, US3, and US4 service surfaces plus capability declarations.
+- **US6 Admin Page**: Depends on REST contracts and at least one completed backend story; full page acceptance depends on US1-US4.
+- **Final Phase**: Depends on the desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: First MVP increment; no dependency on other user stories.
+- **US2 (P1)**: Can run after foundation; independent from US1 except shared metadata infrastructure.
+- **US3 (P1)**: Can create/manage tags after foundation; successful binding write requires US4 validator enforcement to be complete.
+- **US4 (P2)**: Integrity layer for polymorphic resource references; can run in parallel with US1/US2/US3 after foundation.
+- **US5 (P2)**: Requires backend read/write surfaces and capability declarations.
+- **US6 (P2)**: Can start API types/composables after contracts, but full UI validation requires backend endpoints.
+
+### Within Each User Story
+
+- Write tests first and verify they fail.
+- Implement DTOs and repository methods before service methods.
+- Implement services before HTTP/gRPC handlers.
+- Update capability bindings after routes are known.
+- Validate each story at its checkpoint before proceeding.
+
+---
+
+## Parallel Execution Examples
+
+### Foundation
+
+```text
+Task: T007 model tests
+Task: T008 validation tests
+Task: T009 route tests
+Task: T013 common DTOs
+Task: T014 validation helpers
+Task: T017 resource validator registry
+```
+
+### US1 Dictionaries
+
+```text
+Task: T025 dictionary repository tests
+Task: T026 dictionary service tests
+Task: T027 dictionary HTTP tests
+Task: T028 dictionary DTOs
+```
+
+### US2 Taxonomies
+
+```text
+Task: T035 taxonomy repository tests
+Task: T036 taxonomy service tests
+Task: T037 taxonomy HTTP tests
+Task: T038 taxonomy DTOs
+```
+
+### US3 Tags
+
+```text
+Task: T045 tag repository tests
+Task: T046 tag service tests
+Task: T047 tag HTTP tests
+Task: T048 tag DTOs
+```
+
+### US6 Web Admin
+
+```text
+Task: T079 store/composable tests
+Task: T080 page state tests
+Task: T081 TypeScript types
+Task: T082 API composable
+Task: T084 reusable components
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete US1 dictionaries.
+3. Validate US1 through service, REST, gRPC, seed, and manual quickstart dictionary flow.
+4. Stop and demo the first usable metadata governance slice.
+
+### Incremental Delivery
+
+1. Add US2 taxonomy management.
+2. Add US3 tag management.
+3. Add US4 resource type and reference integrity.
+4. Add US5 plugin/framework consumption and explicit seed hardening.
+5. Add US6 full admin page or begin its API/types work in parallel once contracts stabilize.
+
+### Strict Rules During Implementation
+
+- Do not add backend startup AutoMigrate or AutoSeed.
+- Do not add compatibility fallbacks for plugin private metadata in delegated mode.
+- Do not use numeric IDs in API, event, audit, or relationship DTOs for business object references.
+- Do not show UUID/code as the primary human-facing label.
+- Do not introduce user-visible text outside locale resources.
+- Do not bypass capability governance by only editing STS/auth validators.


### PR DESCRIPTION
…y-dev-config-start.md

      - 增加了“切换后的 migrate 和 seed”
      - 明确 make seed = db-seed + capability-seed
      - 写了远程 dev 命令：

     sudo -u powerx POWERX_CONFIG=/etc/powerx-dev/config.yaml make seed

  2. docs/guides/develop/open_capability/readme.md
      - 明确 make capability-check 只校验，不写运行库
      - 明确 db-seed / capability-seed / seed 的边界

  3. make_files/README.md - 补了三个 Make target 的说明

## Summary

- [ ] 简述本次改动目标与范围

## Changes

- [ ] 列出核心改动点（代码/文档/配置）

## Verification

- [ ] 本地验证步骤已执行（请附关键命令/结果）

## WS/TaskBus Contract Checklist（必填）

- [ ] 本次是否涉及 WS/TaskBus（topic、publish/register、envelope、鉴权、tenant/trace）？
- [ ] 若涉及，是否同步更新主契约：`specs/004-eventbus-message-fabric/spec.md`
- [ ] 若涉及 WS 传输，是否同步更新：`specs/023-websocket-notify/spec.md` 与 `specs/023-websocket-notify/contracts/http-openapi.yaml`
- [ ] 是否运行一致性检查：`bash scripts/specs/check_ws_taskbus_contracts.sh`

## Risks

- [ ] 已评估兼容性/回滚影响

