### PR TITLE
已把这 3 个 review 点修完：

### DIFF
--- a/backend/internal/infra/plugin/manager/bootstrap_test.go
+++ b/backend/internal/infra/plugin/manager/bootstrap_test.go
@@ -49,7 +49,7 @@ func TestBootstrapKeepsManagerAvailableWhenPermissionSyncFails(t *testing.T) {
 	require.Equal(t, plugin_mgr.StateInstalled, items[0].State)
 }
 
-func TestBootstrapDefersEnabledPluginRestore(t *testing.T) {
+func TestBootstrapRestoresEnabledPlugin(t *testing.T) {
 	if os.Getenv("POWERX_TEST_PLUGIN_PROCESS") == "1" {
 		runBootstrapTestPluginProcess()
 		return
@@ -109,16 +109,11 @@ func TestBootstrapDefersEnabledPluginRestore(t *testing.T) {
 	require.Equal(t, plugin_mgr.StateEnabled, items[0].State)
 
 	resp := performBootstrapDebugRequest(engine)
-	require.NotContains(t, resp, `"com.powerx.plugins.restore-test"`)
-
-	require.NoError(t, m.Enable(ctx, "com.powerx.plugins.restore-test"))
+	require.Contains(t, resp, `"com.powerx.plugins.restore-test"`)
+	require.Contains(t, resp, `"basePath":"/api/v1"`)
 	t.Cleanup(func() {
 		_ = m.Disable(ctx, "com.powerx.plugins.restore-test")
 	})
-
-	resp = performBootstrapDebugRequest(engine)
-	require.Contains(t, resp, `"com.powerx.plugins.restore-test"`)
-	require.Contains(t, resp, `"basePath":"/api/v1"`)
 }
 
 func TestMountDebugHostUsesExactLocalPluginID(t *testing.T) {

--- a/backend/internal/infra/plugin/manager/manager.go
+++ b/backend/internal/infra/plugin/manager/manager.go
@@ -136,6 +136,30 @@ func (m *managerImpl) Bootstrap(ctx context.Context) error {
 		return nil
 	}
 
+	if err := m.restoreEnabledPlugins(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *managerImpl) restoreEnabledPlugins(ctx context.Context) error {
+	if m.opts.Registry == nil {
+		return plugin_mgr.NewError(plugin_mgr.CodeInternal, plugin_mgr.WithOp("bootstrap.restore_enabled"), plugin_mgr.WithMsg("registry not provided"))
+	}
+	for _, plugin := range m.opts.Registry.List(ctx) {
+		if plugin.State != plugin_mgr.StateEnabled {
+			continue
+		}
+		logger.InfoF(ctx, "[plugin-bootstrap] restore enabled plugin id=%s ver=%s", plugin.ID, plugin.Version)
+		if err := m.Enable(ctx, plugin.ID); err != nil {
+			return plugin_mgr.Wrap(plugin_mgr.CodeLifecycleError, err,
+				plugin_mgr.WithOp("bootstrap.restore_enabled"),
+				plugin_mgr.WithPlugin(plugin.ID),
+				plugin_mgr.WithVersion(plugin.Version),
+			)
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/service/metadata/errors.go
+++ b/backend/internal/service/metadata/errors.go
@@ -18,5 +18,6 @@ const (
 	CodeResourceTypeMissing       = "METADATA_RESOURCE_TYPE_MISSING"
 	CodeResourceBindingDisabled   = "METADATA_RESOURCE_BINDING_DISABLED"
 	CodeResourceValidatorMissing  = "METADATA_RESOURCE_VALIDATOR_MISSING"
+	CodeInvalidParentReference    = "METADATA_INVALID_PARENT_REFERENCE"
 	CodeNotImplemented            = "METADATA_NOT_IMPLEMENTED"
 )

--- a/backend/internal/service/metadata/seed_service_test.go
+++ b/backend/internal/service/metadata/seed_service_test.go
@@ -84,6 +84,32 @@ tags:
 	}
 }
 
+func TestSeedServiceRejectsUnresolvedTaxonomyParent(t *testing.T) {
+	db := newSeedServiceTestDB(t)
+	path := writeSeedTestFile(t, `
+version: 1
+module: corex.metadata
+taxonomies:
+  - namespace: corex.metadata.category
+    name_i18n:
+      zh-CN: 分类
+    max_depth: 3
+    nodes:
+      - code: child
+        parent_code: missing_parent
+        label_i18n:
+          zh-CN: 子节点
+`)
+	svc, err := NewSeedService(SeedServiceOptions{DB: db, SeedPath: path})
+	if err != nil {
+		t.Fatalf("new seed service: %v", err)
+	}
+	_, _, err = svc.Execute(context.Background(), SeedExecutionInput{TenantUUID: uuid.New().String()})
+	if !errors.Is(err, ErrInvalidParentReference) {
+		t.Fatalf("expected invalid parent reference, got %v", err)
+	}
+}
+
 func writeSeedTestFile(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "seed.yaml")

--- a/backend/internal/service/metadata/seed_taxonomy.go
+++ b/backend/internal/service/metadata/seed_taxonomy.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	coremodel "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/model"
@@ -47,7 +48,11 @@ func (s *Service) SeedTaxonomies(ctx context.Context, tenantUUID string, seed Se
 		codeToNode := map[string]*model.TaxonomyNode{}
 		for j := range taxonomy.Nodes {
 			node := taxonomy.Nodes[j]
-			parent := codeToNode[strings.TrimSpace(node.ParentCode)]
+			parentCode := strings.TrimSpace(node.ParentCode)
+			parent := codeToNode[parentCode]
+			if parentCode != "" && parent == nil {
+				return result, fmt.Errorf("%w: taxonomy=%s node=%s parent_code=%s", ErrInvalidParentReference, strings.TrimSpace(taxonomy.Namespace), strings.TrimSpace(node.Code), parentCode)
+			}
 			depth := 1
 			var parentUUID *string
 			if parent != nil {

--- a/backend/internal/service/metadata/validation.go
+++ b/backend/internal/service/metadata/validation.go
@@ -16,6 +16,7 @@ var (
 	ErrAlreadyExists            = errors.New("metadata.already_exists")
 	ErrMissingRequiredLocale    = errors.New("metadata.missing_required_locale")
 	ErrInvalidStatus            = errors.New("metadata.invalid_status")
+	ErrInvalidParentReference   = errors.New("metadata.invalid_parent_reference")
 )
 
 func ValidateMachineIdentifier(value string) error {

--- a/backend/internal/tests/http/admin/metadata/dictionary_http_test.go
+++ b/backend/internal/tests/http/admin/metadata/dictionary_http_test.go
@@ -25,7 +25,9 @@ func TestDictionaryHTTPCreateAndList(t *testing.T) {
 	router := gin.New()
 	protected := router.Group("/api/v1")
 	protected.Use(func(c *gin.Context) {
-		c.Request = c.Request.WithContext(reqctx.WithTenantUUID(c.Request.Context(), tenantUUID))
+		ctx := reqctx.WithTenantUUID(c.Request.Context(), tenantUUID)
+		ctx = reqctx.WithIsRoot(ctx, true)
+		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	})
 	adminhttp.RegisterAPIRoutes(router.Group("/api/v1"), protected, &shared.Deps{DB: db})
@@ -60,7 +62,7 @@ func TestDictionaryHTTPRequiresTenantContext(t *testing.T) {
 	router := gin.New()
 	adminhttp.RegisterAPIRoutes(router.Group("/api/v1"), router.Group("/api/v1"), &shared.Deps{DB: db})
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/metadata/dictionaries", nil).WithContext(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/metadata/dictionaries", nil).WithContext(reqctx.WithIsRoot(context.Background(), true))
 	router.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected tenant context failure, got %d", rec.Code)

--- a/backend/internal/tests/http/admin/metadata/resource_type_http_test.go
+++ b/backend/internal/tests/http/admin/metadata/resource_type_http_test.go
@@ -32,7 +32,9 @@ func TestResourceTypeHTTPCreateListAndUpdate(t *testing.T) {
 	router := gin.New()
 	protected := router.Group("/api/v1")
 	protected.Use(func(c *gin.Context) {
-		c.Request = c.Request.WithContext(reqctx.WithTenantUUID(c.Request.Context(), tenantUUID))
+		ctx := reqctx.WithTenantUUID(c.Request.Context(), tenantUUID)
+		ctx = reqctx.WithIsRoot(ctx, true)
+		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	})
 	adminhttp.RegisterAPIRoutes(router.Group("/api/v1"), protected, &shared.Deps{
@@ -100,7 +102,9 @@ func TestResourceTypeHTTPRejectsEnabledWithoutValidatorKey(t *testing.T) {
 	router := gin.New()
 	protected := router.Group("/api/v1")
 	protected.Use(func(c *gin.Context) {
-		c.Request = c.Request.WithContext(reqctx.WithTenantUUID(c.Request.Context(), tenantUUID))
+		ctx := reqctx.WithTenantUUID(c.Request.Context(), tenantUUID)
+		ctx = reqctx.WithIsRoot(ctx, true)
+		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	})
 	adminhttp.RegisterAPIRoutes(router.Group("/api/v1"), protected, &shared.Deps{DB: db})

--- a/backend/internal/tests/http/admin/metadata/tag_http_test.go
+++ b/backend/internal/tests/http/admin/metadata/tag_http_test.go
@@ -32,7 +32,9 @@ func TestTagHTTPCreateReplaceBindingAndList(t *testing.T) {
 	router := gin.New()
 	protected := router.Group("/api/v1")
 	protected.Use(func(c *gin.Context) {
-		c.Request = c.Request.WithContext(reqctx.WithTenantUUID(c.Request.Context(), tenantUUID))
+		ctx := reqctx.WithTenantUUID(c.Request.Context(), tenantUUID)
+		ctx = reqctx.WithIsRoot(ctx, true)
+		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	})
 	adminhttp.RegisterAPIRoutes(router.Group("/api/v1"), protected, &shared.Deps{

--- a/backend/internal/tests/http/admin/metadata/taxonomy_http_test.go
+++ b/backend/internal/tests/http/admin/metadata/taxonomy_http_test.go
@@ -24,7 +24,9 @@ func TestTaxonomyHTTPCreateNodeAndList(t *testing.T) {
 	router := gin.New()
 	protected := router.Group("/api/v1")
 	protected.Use(func(c *gin.Context) {
-		c.Request = c.Request.WithContext(reqctx.WithTenantUUID(c.Request.Context(), tenantUUID))
+		ctx := reqctx.WithTenantUUID(c.Request.Context(), tenantUUID)
+		ctx = reqctx.WithIsRoot(ctx, true)
+		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	})
 	adminhttp.RegisterAPIRoutes(router.Group("/api/v1"), protected, &shared.Deps{DB: db})

--- a/backend/internal/transport/http/admin/metadata/api.go
+++ b/backend/internal/transport/http/admin/metadata/api.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ArtisanCloud/PowerX/internal/app/shared"
+	iamsvc "github.com/ArtisanCloud/PowerX/internal/service/iam"
 	metasvc "github.com/ArtisanCloud/PowerX/internal/service/metadata"
 	"github.com/ArtisanCloud/PowerX/pkg/corex/iam/reqctx"
 	"github.com/ArtisanCloud/PowerX/pkg/dto"
@@ -24,35 +25,81 @@ func RegisterAPIRoutes(_ *gin.RouterGroup, protected *gin.RouterGroup, deps *sha
 		}
 	}
 	g := protected.Group("/admin/metadata")
-	g.GET("/dictionaries", h.listDictionaryNamespaces)
-	g.POST("/dictionaries", h.createDictionaryNamespace)
-	g.PATCH("/dictionaries/:namespace_uuid", h.updateDictionaryNamespace)
-	g.GET("/dictionaries/:namespace_uuid/items", h.listDictionaryItems)
-	g.POST("/dictionaries/:namespace_uuid/items", h.createDictionaryItem)
-	g.PATCH("/dictionary-items/:item_uuid", h.updateDictionaryItem)
-	g.DELETE("/dictionary-items/:item_uuid", h.deleteDictionaryItem)
-	g.GET("/taxonomies", h.listTaxonomies)
-	g.POST("/taxonomies", h.createTaxonomy)
-	g.PATCH("/taxonomies/:taxonomy_uuid", h.updateTaxonomy)
-	g.GET("/taxonomies/:taxonomy_uuid/nodes", h.listTaxonomyNodes)
-	g.POST("/taxonomies/:taxonomy_uuid/nodes", h.createTaxonomyNode)
-	g.PATCH("/taxonomy-nodes/:node_uuid", h.updateTaxonomyNode)
-	g.DELETE("/taxonomy-nodes/:node_uuid", h.deleteTaxonomyNode)
-	g.POST("/taxonomy-nodes/:node_uuid/move", h.moveTaxonomyNode)
-	g.GET("/tags", h.listTags)
-	g.POST("/tags", h.createTag)
-	g.PATCH("/tags/:tag_uuid", h.updateTag)
-	g.DELETE("/tags/:tag_uuid", h.deleteTag)
-	g.POST("/tags/merge", h.mergeTags)
-	g.GET("/tag-bindings", h.listTagBindings)
-	g.PUT("/tag-bindings", h.replaceTagBindings)
-	g.GET("/resource-types", h.listResourceTypes)
-	g.POST("/resource-types", h.registerResourceType)
-	g.PATCH("/resource-types/:resource_type_uuid", h.updateResourceType)
+	dictionaryRead := requireMetadataPermission(deps, "dictionary", "read")
+	dictionaryManage := requireMetadataPermission(deps, "dictionary", "manage")
+	taxonomyRead := requireMetadataPermission(deps, "taxonomy", "read")
+	taxonomyManage := requireMetadataPermission(deps, "taxonomy", "manage")
+	tagRead := requireMetadataPermission(deps, "tag", "read")
+	tagManage := requireMetadataPermission(deps, "tag", "manage")
+	resourceTypeRead := requireMetadataPermission(deps, "resource_type", "read")
+	resourceTypeManage := requireMetadataPermission(deps, "resource_type", "manage")
+
+	g.GET("/dictionaries", dictionaryRead, h.listDictionaryNamespaces)
+	g.POST("/dictionaries", dictionaryManage, h.createDictionaryNamespace)
+	g.PATCH("/dictionaries/:namespace_uuid", dictionaryManage, h.updateDictionaryNamespace)
+	g.GET("/dictionaries/:namespace_uuid/items", dictionaryRead, h.listDictionaryItems)
+	g.POST("/dictionaries/:namespace_uuid/items", dictionaryManage, h.createDictionaryItem)
+	g.PATCH("/dictionary-items/:item_uuid", dictionaryManage, h.updateDictionaryItem)
+	g.DELETE("/dictionary-items/:item_uuid", dictionaryManage, h.deleteDictionaryItem)
+	g.GET("/taxonomies", taxonomyRead, h.listTaxonomies)
+	g.POST("/taxonomies", taxonomyManage, h.createTaxonomy)
+	g.PATCH("/taxonomies/:taxonomy_uuid", taxonomyManage, h.updateTaxonomy)
+	g.GET("/taxonomies/:taxonomy_uuid/nodes", taxonomyRead, h.listTaxonomyNodes)
+	g.POST("/taxonomies/:taxonomy_uuid/nodes", taxonomyManage, h.createTaxonomyNode)
+	g.PATCH("/taxonomy-nodes/:node_uuid", taxonomyManage, h.updateTaxonomyNode)
+	g.DELETE("/taxonomy-nodes/:node_uuid", taxonomyManage, h.deleteTaxonomyNode)
+	g.POST("/taxonomy-nodes/:node_uuid/move", taxonomyManage, h.moveTaxonomyNode)
+	g.GET("/tags", tagRead, h.listTags)
+	g.POST("/tags", tagManage, h.createTag)
+	g.PATCH("/tags/:tag_uuid", tagManage, h.updateTag)
+	g.DELETE("/tags/:tag_uuid", tagManage, h.deleteTag)
+	g.POST("/tags/merge", tagManage, h.mergeTags)
+	g.GET("/tag-bindings", tagRead, h.listTagBindings)
+	g.PUT("/tag-bindings", tagManage, h.replaceTagBindings)
+	g.GET("/resource-types", resourceTypeRead, h.listResourceTypes)
+	g.POST("/resource-types", resourceTypeManage, h.registerResourceType)
+	g.PATCH("/resource-types/:resource_type_uuid", resourceTypeManage, h.updateResourceType)
 }
 
 type handler struct {
 	service *metasvc.Service
+}
+
+func requireMetadataPermission(deps *shared.Deps, resource, action string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if deps == nil || deps.DB == nil {
+			dto.ResponseError(c, http.StatusInternalServerError, "metadata.authorization_unavailable", nil)
+			c.Abort()
+			return
+		}
+
+		ctx := c.Request.Context()
+		actor := iamsvc.ActorContext{IsRoot: reqctx.IsRoot(ctx), TenantUUID: strings.TrimSpace(reqctx.GetTenantUUID(ctx))}
+		if actor.IsRoot {
+			c.Next()
+			return
+		}
+
+		memberID := reqctx.GetMemberID(ctx)
+		if memberID == 0 || actor.TenantUUID == "" {
+			dto.ResponseError(c, http.StatusUnauthorized, "metadata.authorization_context_required", nil)
+			c.Abort()
+			return
+		}
+
+		pass, err := iamsvc.NewRBACService(deps.DB).Enforce(ctx, actor, actor.TenantUUID, memberID, "metadata", resource, action)
+		if err != nil {
+			dto.ResponseError(c, http.StatusForbidden, "metadata.rbac_check_failed", err)
+			c.Abort()
+			return
+		}
+		if !pass {
+			dto.ResponseError(c, http.StatusForbidden, "metadata.permission_denied", nil)
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
 }
 
 func (h *handler) notImplemented(c *gin.Context) {

--- a/backend/internal/transport/http/admin/metadata/error_mapping.go
+++ b/backend/internal/transport/http/admin/metadata/error_mapping.go
@@ -45,6 +45,8 @@ func respondError(c *gin.Context, err error) {
 		dto.ResponseError(c, http.StatusConflict, metasvc.CodeResourceBindingDisabled, err)
 	case errors.Is(err, metasvc.ErrResourceValidatorMissing):
 		dto.ResponseError(c, http.StatusConflict, metasvc.CodeResourceValidatorMissing, err)
+	case errors.Is(err, metasvc.ErrInvalidParentReference):
+		dto.ResponseError(c, http.StatusBadRequest, metasvc.CodeInvalidParentReference, err)
 	default:
 		dto.ResponseError(c, http.StatusNotImplemented, metasvc.CodeNotImplemented, err)
 	}


### PR DESCRIPTION
  1. seed_taxonomy.go 现在 parent_code 非空但找不到已解析父节点时会直接失败，返回 METADATA_INVALID_PARENT_REFERENCE，不会再静默把子节点降级成根节点。补了对应 seed 测试。

  2. admin/metadata 路由 RBAC 已在 backend/internal/transport/http/admin/metadata/api.go 给所有元数据管理路由挂上实际 IAM RBAC： metadata.dictionary/read|manage、metadata.taxonomy/read|manage、metadata.tag/read|manage、metadata.resource_type/read|manage。 root 仍按现有 IAM 语义放行，普通成员必须有对应权限。

  3. 插件重启恢复 Bootstrap() 现在会恢复 registry 中 StateEnabled 的插件，重新启动进程并挂载 API/Admin 代理。测试也从“延迟恢复”改成“启动后必须恢复可用”。

  验证已通过：

  cd backend && go test ./internal/service/metadata ./internal/tests/http/admin/metadata ./internal/infra/plugin/manager
  git diff --check
  make capability-check

  capability-check 当前结果仍正常：declared=882，rest_routes=692，candidates=852，无 uncovered route。

## Summary

- [ ] 简述本次改动目标与范围

## Changes

- [ ] 列出核心改动点（代码/文档/配置）

## Verification

- [ ] 本地验证步骤已执行（请附关键命令/结果）

## WS/TaskBus Contract Checklist（必填）

- [ ] 本次是否涉及 WS/TaskBus（topic、publish/register、envelope、鉴权、tenant/trace）？
- [ ] 若涉及，是否同步更新主契约：`specs/004-eventbus-message-fabric/spec.md`
- [ ] 若涉及 WS 传输，是否同步更新：`specs/023-websocket-notify/spec.md` 与 `specs/023-websocket-notify/contracts/http-openapi.yaml`
- [ ] 是否运行一致性检查：`bash scripts/specs/check_ws_taskbus_contracts.sh`

## Risks

- [ ] 已评估兼容性/回滚影响

