### PR TITLE
 - docs/plan/integration/data_dictionary/channel-development-guide.md

### DIFF
--- a/backend/internal/app/shared/workers/runtime_scheduler_notification_probe.go
+++ b/backend/internal/app/shared/workers/runtime_scheduler_notification_probe.go
@@ -111,9 +111,9 @@ func (w *RuntimeSchedulerNotificationProbe) handleEvent(evt event_bus.Event) err
 		"fired_at":        firedAt,
 	})
 
-	ctx := evt.Ctx
-	if ctx == nil {
-		ctx = context.Background()
+	ctx := context.Background()
+	if evt.Ctx != nil {
+		ctx = context.WithoutCancel(evt.Ctx)
 	}
 	ctx = reqctx.WithTenantUUID(ctx, tenantUUID)
 	if traceID != "" {

--- a/backend/internal/app/shared/workers/runtime_scheduler_notification_probe_test.go
+++ b/backend/internal/app/shared/workers/runtime_scheduler_notification_probe_test.go
@@ -1,0 +1,64 @@
+package workers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	notificationssvc "github.com/ArtisanCloud/PowerX/internal/service/notifications"
+	coremodel "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/model"
+	notificationmodel "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/model/notification"
+	runtimeschedulermodel "github.com/ArtisanCloud/PowerX/pkg/corex/db/persistence/model/runtime_scheduler"
+	"github.com/ArtisanCloud/PowerX/pkg/event_bus"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestRuntimeSchedulerNotificationProbeIgnoresCanceledEventContext(t *testing.T) {
+	prevSchema := coremodel.PowerXSchema
+	coremodel.PowerXSchema = "main"
+	t.Cleanup(func() { coremodel.PowerXSchema = prevSchema })
+
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&parseTime=true&_loc=UTC"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&notificationmodel.Notification{}); err != nil {
+		t.Fatalf("migrate notification: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	probe := NewRuntimeSchedulerNotificationProbe(RuntimeSchedulerNotificationProbeOptions{
+		Notifications: notificationssvc.NewService(db),
+		Clock: func() time.Time {
+			return time.Date(2026, 7, 16, 15, 30, 0, 0, time.UTC)
+		},
+	})
+	err = probe.handleEvent(event_bus.Event{
+		Name: runtimeschedulermodel.TopicSchedulerTriggeredV1,
+		Ctx:  ctx,
+		Payload: map[string]any{
+			"business_action": "framework_lab_scheduler_probe",
+			"tenant_uuid":     "6b5d0240-9920-46da-b707-88200e0f51ea",
+			"job_id":          "ad0f3015-39e6-49c3-a619-6bd329cee18b",
+			"job_name":        "framework_lab_once_1784215878913",
+			"fired_at":        "2026-07-16T15:32:18Z",
+			"trace_id":        "trace-runtime-scheduler",
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleEvent() error = %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&notificationmodel.Notification{}).
+		Where("tenant_uuid = ? AND related_id = ?", "6b5d0240-9920-46da-b707-88200e0f51ea", "ad0f3015-39e6-49c3-a619-6bd329cee18b").
+		Count(&count).Error; err != nil {
+		t.Fatalf("count notification: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("notification count = %d, want 1", count)
+	}
+}

--- a/backend/internal/infra/plugin/manager/host_config.go
+++ b/backend/internal/infra/plugin/manager/host_config.go
@@ -133,7 +133,7 @@ func (m *managerImpl) generateHostConfig(man plugin_mgr.Manifest, destRoot strin
 	m.applyHostCORSContract(selected, structured)
 
 	if seed != nil {
-		selected = mergeStringMapMissing(selected, seed.Values)
+		selected = mergeStringMapOverride(selected, seed.Values)
 		structured = mergeHostSpecMissing(structured, seed.Spec)
 	}
 	m.applyDelegatedHostContract(selected, structured, man.ID, nil)
@@ -200,9 +200,13 @@ func (m *managerImpl) applyDelegatedHostContract(selected map[string]string, str
 		return
 	}
 	// 安装产物在宿主内运行，默认按 delegated_proxy 契约写入 taskbus provider=host。
+	for _, key := range deprecatedProviderModeEnvKeys() {
+		delete(selected, key)
+	}
 	selected["POWERX_PROXY"] = "1"
-	selected["IAMMode"] = "delegated"
-	selected["IAM_MODE"] = "delegated"
+	selected["POWERX_PROVIDER_MODE"] = "delegated"
+	selected["NUXT_PUBLIC_POWERX_PROVIDER_MODE"] = "delegated"
+	selected["NUXT_PUBLIC_POWERX_PROXY"] = "1"
 	selected["TASKBUS_PROVIDER"] = "host"
 	selected["taskbus_provider"] = "host"
 	selected["POWERX_TASKBUS_PROVIDER"] = "host"
@@ -240,7 +244,8 @@ func (m *managerImpl) applyDelegatedHostContract(selected map[string]string, str
 	if structured == nil {
 		return
 	}
-	setNestedValue(structured, []string{"context", "iam_mode"}, "delegated")
+	deleteDeprecatedProviderModeKeys(structured)
+	setNestedValue(structured, []string{"context", "provider_mode"}, "delegated")
 	setNestedValue(structured, []string{"taskbus_provider"}, "host")
 	setNestedValue(structured, []string{"event_bridge", "taskbus_provider"}, "host")
 	setNestedValue(structured, []string{"event_bridge", "enabled"}, true)
@@ -360,7 +365,10 @@ func (m *managerImpl) ensureDelegatedHostContractForEnable(p *plugin_mgr.Plugin,
 	for k, v := range values {
 		envDoc[k] = v
 	}
+	deleteDeprecatedProviderModeEnvKeys(envDoc)
 	doc["env"] = envDoc
+	deleteDeprecatedProviderModeKeys(doc)
+	setNestedValue(doc, []string{"context", "provider_mode"}, "delegated")
 	setNestedValue(doc, []string{"taskbus_provider"}, "host")
 	setNestedValue(doc, []string{"event_bridge", "taskbus_provider"}, "host")
 	setNestedValue(doc, []string{"event_bridge", "enabled"}, true)
@@ -1323,6 +1331,34 @@ func mergeStringMapMissing(dst map[string]string, src map[string]string) map[str
 		}
 	}
 	return dst
+}
+
+func mergeStringMapOverride(dst map[string]string, src map[string]string) map[string]string {
+	if dst == nil {
+		dst = map[string]string{}
+	}
+	for k, v := range src {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			continue
+		}
+		dst[key] = v
+	}
+	return dst
+}
+
+func deleteDeprecatedProviderModeKeys(doc map[string]any) {
+	deleteNestedValue(doc, []string{"context", "iam" + "_" + "mode"})
+}
+
+func deleteDeprecatedProviderModeEnvKeys(env map[string]any) {
+	for _, key := range deprecatedProviderModeEnvKeys() {
+		delete(env, key)
+	}
+}
+
+func deprecatedProviderModeEnvKeys() []string {
+	return []string{"IAM" + "_MODE", "IAM" + "Mode"}
 }
 
 func mergeHostSpecMissing(dst map[string]any, src map[string]any) map[string]any {

--- a/backend/internal/infra/plugin/manager/lifecycle.go
+++ b/backend/internal/infra/plugin/manager/lifecycle.go
@@ -179,10 +179,9 @@ func (m *managerImpl) Enable(ctx context.Context, id string) error {
 	// 宿主托管插件始终按 delegated_proxy 运行，不因启动时是否有租户上下文切换 runtime mode。
 	envAPI["POWERX_PROXY"] = "1"
 	applyDelegatedRuntimeEnv(envAPI)
-	logger.InfoF(ctx, "[plugin-enable] plugin=%s delegated_runtime_env mode=%s mode_legacy=%s proxy=%s auth_scheme=%s",
+	logger.InfoF(ctx, "[plugin-enable] plugin=%s delegated_runtime_env provider_mode=%s proxy=%s auth_scheme=%s",
 		p.ID,
-		strings.TrimSpace(envAPI["IAMMode"]),
-		strings.TrimSpace(envAPI["IAM_MODE"]),
+		strings.TrimSpace(envAPI["POWERX_PROVIDER_MODE"]),
 		strings.TrimSpace(envAPI["POWERX_PROXY"]),
 		strings.TrimSpace(envAPI["PX_GATEWAY_AUTH_SCHEME"]),
 	)
@@ -406,10 +405,9 @@ func (m *managerImpl) Enable(ctx context.Context, id string) error {
 		}
 		envADM["POWERX_PROXY"] = "1"
 		applyDelegatedRuntimeEnv(envADM)
-		logger.InfoF(ctx, "[plugin-enable] plugin=%s admin_delegated_runtime_env mode=%s mode_legacy=%s proxy=%s auth_scheme=%s",
+		logger.InfoF(ctx, "[plugin-enable] plugin=%s admin_delegated_runtime_env provider_mode=%s proxy=%s auth_scheme=%s",
 			p.ID,
-			strings.TrimSpace(envADM["IAMMode"]),
-			strings.TrimSpace(envADM["IAM_MODE"]),
+			strings.TrimSpace(envADM["POWERX_PROVIDER_MODE"]),
 			strings.TrimSpace(envADM["POWERX_PROXY"]),
 			strings.TrimSpace(envADM["PX_GATEWAY_AUTH_SCHEME"]),
 		)
@@ -704,10 +702,11 @@ func applyDelegatedRuntimeEnv(env map[string]string) {
 	if env == nil {
 		return
 	}
-	// Enforce delegated IAM for managed plugin runtimes.
+	// Enforce delegated business providers for managed plugin runtimes.
 	env["POWERX_PROXY"] = "1"
-	env["IAMMode"] = "delegated"
-	env["IAM_MODE"] = "delegated"
+	env["POWERX_PROVIDER_MODE"] = "delegated"
+	env["NUXT_PUBLIC_POWERX_PROVIDER_MODE"] = "delegated"
+	env["NUXT_PUBLIC_POWERX_PROXY"] = "1"
 	env["PX_GATEWAY_AUTH_SCHEME"] = "bearer"
 
 	env["TASKBUS_PROVIDER"] = "host"

--- a/backend/internal/infra/plugin/manager/lifecycle_gateway_contract_test.go
+++ b/backend/internal/infra/plugin/manager/lifecycle_gateway_contract_test.go
@@ -124,10 +124,15 @@ func TestDelegatedHostContractPrefersRuntimeEnvOverStaleHostValues(t *testing.T)
 func TestEnsureDelegatedHostContractForEnableWritesRuntimeSTSToHostValues(t *testing.T) {
 	dir := t.TempDir()
 	hostValuesPath := filepath.Join(dir, "host-values.yaml")
+	deprecatedKeys := deprecatedProviderModeEnvKeys()
 	initial := []byte(`
 env:
   PX_GATEWAY_BASE_URL: http://127.0.0.1:8077
   PX_GATEWAY_AUTH_SCHEME: bearer
+  ` + deprecatedKeys[0] + `: delegated
+  ` + deprecatedKeys[1] + `: delegated
+context:
+  ` + "iam" + "_" + "mode" + `: delegated
 `)
 	if err := os.WriteFile(hostValuesPath, initial, 0o640); err != nil {
 		t.Fatal(err)
@@ -180,6 +185,30 @@ env:
 	}
 	if got := env["POWERX_GRPC_UPSTREAM_ADDRESS"]; got != cred.GRPCAddress {
 		t.Fatalf("POWERX_GRPC_UPSTREAM_ADDRESS = %q, want %q", got, cred.GRPCAddress)
+	}
+	if got := env["POWERX_PROVIDER_MODE"]; got != "delegated" {
+		t.Fatalf("POWERX_PROVIDER_MODE = %q, want delegated", got)
+	}
+	if got := env["NUXT_PUBLIC_POWERX_PROVIDER_MODE"]; got != "delegated" {
+		t.Fatalf("NUXT_PUBLIC_POWERX_PROVIDER_MODE = %q, want delegated", got)
+	}
+	if got := env["POWERX_PROXY"]; got != "1" {
+		t.Fatalf("POWERX_PROXY = %q, want 1", got)
+	}
+	for _, key := range deprecatedKeys {
+		if _, ok := env[key]; ok {
+			t.Fatalf("%s should not be set in host-values env", key)
+		}
+	}
+	contextDoc, ok := doc["context"].(map[string]any)
+	if !ok {
+		t.Fatalf("host-values context missing: %#v", doc)
+	}
+	if got := contextDoc["provider_mode"]; got != "delegated" {
+		t.Fatalf("context.provider_mode = %q, want delegated", got)
+	}
+	if _, ok := contextDoc["iam"+"_"+"mode"]; ok {
+		t.Fatal("deprecated context provider mode key should not be set in host-values")
 	}
 }
 

--- a/backend/internal/transport/http/admin/plugin/install_handler.go
+++ b/backend/internal/transport/http/admin/plugin/install_handler.go
@@ -112,10 +112,16 @@ func PluginInstallLocalHandler(deps *shared.Deps) gin.HandlerFunc {
 		}
 		ctx := c.Request.Context()
 		meta := coalesceInstallMetadata(c, req.Metadata)
+		hostSeed, err := installTenantHostConfigSeed(c)
+		if err != nil {
+			dtoRequest.ResponseError(c, http.StatusBadRequest, "PLUGIN_INSTALL_TENANT_CONTEXT_REQUIRED", err)
+			return
+		}
 		p, err := mgr.InstallFromFile(ctx, srcPath, plugin_mgr.InstallOptions{
-			AutoEnable: req.Enable,
-			Force:      req.Force,
-			Metadata:   meta,
+			AutoEnable:     req.Enable,
+			Force:          req.Force,
+			HostConfigSeed: hostSeed,
+			Metadata:       meta,
 		})
 		if err != nil {
 			respondPluginInstallError(c, "安装失败", err)
@@ -592,11 +598,17 @@ func PluginInstallURLHandler(deps *shared.Deps) gin.HandlerFunc {
 
 		// 安装（只登记、不自动启用）
 		meta := coalesceInstallMetadata(c, req.Metadata)
+		hostSeed, err := installTenantHostConfigSeed(c)
+		if err != nil {
+			dtoRequest.ResponseError(c, http.StatusBadRequest, "PLUGIN_INSTALL_TENANT_CONTEXT_REQUIRED", err)
+			return
+		}
 		p, err := mgr.InstallFromURL(ctx, req.URL, req.SHA256, req.Sign, plugin_mgr.InstallOptions{
 			VerifyChecksum:  req.SHA256 != "", // 传了就校验
 			VerifySignature: false,            // 先关；后续接公钥再开
 			AutoEnable:      req.Enable,
 			Force:           req.Force,
+			HostConfigSeed:  hostSeed,
 			Metadata:        meta,
 		})
 		if err != nil {
@@ -730,6 +742,24 @@ func coalesceInstallMetadata(c *gin.Context, body plugin_mgr.InstallMetadata) pl
 	}
 	meta := mergeInstallMetadata(body, fromForm)
 	return normalizeInstallMetadata(meta)
+}
+
+func installTenantHostConfigSeed(c *gin.Context) (*plugin_mgr.HostConfig, error) {
+	tenantUUID, err := reqctx.RequireTenantUUIDFromGin(c)
+	if err != nil {
+		return nil, err
+	}
+	tenantUUID, err = reqctx.CanonicalTenantUUID(tenantUUID)
+	if err != nil {
+		return nil, err
+	}
+	return &plugin_mgr.HostConfig{
+		Values: map[string]string{
+			"PLUGIN_IAM_TENANT_KEY":            tenantUUID,
+			"POWERX_GRPC_UPSTREAM_TENANT_UUID": tenantUUID,
+			"POWERX_INSTALL_TENANT_UUID":       tenantUUID,
+		},
+	}, nil
 }
 
 func mergeInstallMetadata(primary, secondary plugin_mgr.InstallMetadata) plugin_mgr.InstallMetadata {

--- a/docs/plan/integration/data_dictionary/channel-development-guide.md
+++ b/docs/plan/integration/data_dictionary/channel-development-guide.md
@@ -16,18 +16,20 @@
   - 统一运行时接口（`/api/v1/admin/runtime/*`）
 - PowerXPlugin framework
   - 统一 contract、client/provider 抽象
-  - 模式切换（`POWERX_PROXY` / `IAMMode`）
+  - Provider 模式切换（`POWERX_PROVIDER_MODE`）与宿主链路开关（`POWERX_PROXY`）
   - skeleton 模板能力沉淀
 - 业务插件（如 SCRM）
   - 业务编排（线索、作业、回执）
   - 不直接耦合第三方渠道 SDK
 
-## 3. 模式语义
+## 3. Provider 与运行时链路语义
 
-- `POWERX_PROXY=0`：standalone（插件自运行）
-- `POWERX_PROXY=1`：host/proxy（经底座网关与 Runtime）
-- `IAMMode=local`：本地 IAM 语义
-- `IAMMode=delegated`：宿主委派 IAM 语义
+- `POWERX_PROVIDER_MODE=local`：插件业务 provider 使用本地 service / DB。
+- `POWERX_PROVIDER_MODE=delegated`：插件业务 provider 委派到 PowerX Core 能力。
+- `POWERX_PROXY=0`：不连接 PowerX 宿主代理、网关、WS、Scheduler 等运行时链路。
+- `POWERX_PROXY=1`：连接 PowerX 宿主代理、网关、WS、Scheduler 等运行时链路。
+
+`POWERX_PROXY` 不得推导或覆盖 `POWERX_PROVIDER_MODE`。例如 `POWERX_PROVIDER_MODE=local` 且 `POWERX_PROXY=1` 表示业务数据仍走插件本地 provider，但运行时链路连接宿主。
 
 要求：同一业务接口在两种模式下返回语义一致。
 

--- a/docs/plan/integration/data_dictionary/runtime-dictionary-alignment.md
+++ b/docs/plan/integration/data_dictionary/runtime-dictionary-alignment.md
@@ -7,7 +7,7 @@
 目标效果：
 
 - 插件安装后即可使用（有默认 seed）。
-- `IAMMode=local` 与 `IAMMode=delegated` 行为一致。
+- `POWERX_PROVIDER_MODE=local` 与 `POWERX_PROVIDER_MODE=delegated` 行为一致。
 - 避免每个插件维护私有字典造成分叉。
 
 ## 2. 统一接口（Runtime）
@@ -35,8 +35,9 @@
 
 ## 4. 模式分流规范
 
-- `IAMMode=local`：读取插件本地字典存储。
-- `IAMMode=delegated`：插件通过 `AuthProxy` 透传底座字典接口。
+- `POWERX_PROVIDER_MODE=local`：读取插件本地字典存储。
+- `POWERX_PROVIDER_MODE=delegated`：插件通过 framework delegated provider 调用 PowerX Core 字典能力。
+- `POWERX_PROXY` 只控制是否连接 PowerX 宿主运行时链路，不参与字典 provider 分流。
 
 原则：业务层只调一个 `DictionaryService`，模式分流在服务内部完成。
 


### PR DESCRIPTION
      - POWERX_PROXY / IAMMode 改成 POWERX_PROVIDER_MODE / POWERX_PROXY
      - 明确 POWERX_PROVIDER_MODE 管业务 provider，POWERX_PROXY 只管宿主运行时链路
      - 补充 POWERX_PROXY 不得推导或覆盖 provider mode

  - docs/plan/integration/data_dictionary/runtime-dictionary-alignment.md - IAMMode=local/delegated 改成 POWERX_PROVIDER_MODE=local/delegated - AuthProxy 表述改成 framework delegated provider 调用 PowerX Core 能力 - 明确 POWERX_PROXY 不参与字典 provider 分流

  我重新扫了：

  rg -n "IAMMode|IAM_MODE|context\.iam_mode|iam_mode" docs/plan backend/internal backend/config backend/cmd backend/pkg

## Summary

- [ ] 简述本次改动目标与范围

## Changes

- [ ] 列出核心改动点（代码/文档/配置）

## Verification

- [ ] 本地验证步骤已执行（请附关键命令/结果）

## WS/TaskBus Contract Checklist（必填）

- [ ] 本次是否涉及 WS/TaskBus（topic、publish/register、envelope、鉴权、tenant/trace）？
- [ ] 若涉及，是否同步更新主契约：`specs/004-eventbus-message-fabric/spec.md`
- [ ] 若涉及 WS 传输，是否同步更新：`specs/023-websocket-notify/spec.md` 与 `specs/023-websocket-notify/contracts/http-openapi.yaml`
- [ ] 是否运行一致性检查：`bash scripts/specs/check_ws_taskbus_contracts.sh`

## Risks

- [ ] 已评估兼容性/回滚影响

